### PR TITLE
Update README -- Analyze takes in the whole event

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ npm install realtime-bpm-analyzer -S
     });
     // Attach realTime function to audioprocess event.inputBuffer (AudioBuffer)
     scriptProcessorNode.onaudioprocess = function (e) {
-        onAudioProcess.analyze(e.inputBuffer);
+        onAudioProcess.analyze(e);
     };
     ```
 


### PR DESCRIPTION
onAudioProcess.analyze expects event, rather than event.inputBuffer