### PR TITLE
Update import statement in Usage section step 3

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -91,7 +91,7 @@ npm run test:report
     
 3. Now you have just to configure the tool and attach it to the [audioprocess](https://developer.mozilla.org/en-US/docs/Web/Events/audioprocess) event like this :
     ```javascript
-    import RealTimeBPMAnalyzer from 'realtime-bpm-analyzer';
+    import { RealTimeBPMAnalyzer } from 'realtime-bpm-analyzer';
 
     const onAudioProcess = new RealTimeBPMAnalyzer({
         scriptNode: {


### PR DESCRIPTION
```console
export 'default' (imported as 'RealTimeBPMAnalyzer') was not found in 'realtime-bpm-analyzer' 
(possible exports: RealTimeBPMAnalyzer)
```

Existing import statement gives us the error above.

So I changed default export to object export