### PR TITLE
Prevent uncaught exceptions when processor is already registered

### DIFF
--- a/processor/realtime-bpm-processor.ts
+++ b/processor/realtime-bpm-processor.ts
@@ -130,6 +130,15 @@ export class RealTimeBpmProcessor extends AudioWorkletProcessor {
 /**
  * Mandatory Registration to use the processor
  */
-registerProcessor(realtimeBpmProcessorName, RealTimeBpmProcessor);
+try {
+  registerProcessor(realtimeBpmProcessorName, RealTimeBpmProcessor);
+}
+catch (error) {
+  if (error?.name === 'NotSupportedError') {
+    console.warn(`Failed to register ${realtimeBpmProcessorName}. This probably means it was already registered.`);
+    return;
+  }
+  throw error;
+}
 
 export default {};


### PR DESCRIPTION
This allows the processor to be re-registered without this exception:

> Uncaught DOMException: Failed to execute 'registerProcessor' on 'AudioWorkletGlobalScope': An AudioWorkletProcessor with name:"realtime-bpm-processor" is already registered.

It's useful for my React app in which I setup/start/stop the analyzer using a button.

> NotSupportedError
Thrown under the following conditions:
>
> - The name is an empty string.
> - A constructor under the given name is already registered. Registering the same name twice is not allowed.

https://developer.mozilla.org/en-US/docs/Web/API/AudioWorkletGlobalScope/registerProcessor#exceptions