### PR TITLE
docs: interactive BPM analyzer hero + GTM analytics + quality gates

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,7 +94,7 @@ jobs:
   # Deploy documentation
   docs:
     name: Deploy Documentation
-    needs: build
+    needs: [build, release]
     runs-on: ubuntu-latest
     environment:
       name: github-pages
@@ -105,6 +105,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          ref: main
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -122,6 +123,12 @@ jobs:
 
       - name: Install docs dependencies
         run: cd docs && npm ci
+
+      - name: Docs typecheck
+        run: cd docs && npm run typecheck
+
+      - name: Docs lint
+        run: cd docs && npm run lint
 
       - name: Setup Pages
         uses: actions/configure-pages@v6

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,7 @@ src/generated-processor.ts
 docs/.vitepress/dist
 docs/.vitepress/cache
 docs/node_modules
+
+# Product-management docs kept local only — not tracked in git.
+CLAUDE.md
+NORTH-STAR.md

--- a/docs/.vitepress/components/BpmHeroTool.vue
+++ b/docs/.vitepress/components/BpmHeroTool.vue
@@ -1,0 +1,1228 @@
+<script setup lang="ts">
+import { ref, shallowRef, computed, onBeforeUnmount } from 'vue'
+import {
+  FileAudio,
+  Mic,
+  Radio,
+  Volume2,
+  VolumeX,
+  ShieldCheck,
+} from 'lucide-vue-next'
+import {
+  analyzeFullBuffer,
+  createRealtimeBpmAnalyzer,
+  type BpmAnalyzer,
+  type BpmCandidates,
+} from 'realtime-bpm-analyzer'
+import { useAnalytics } from '../composables/useAnalytics'
+
+type Mode = 'file' | 'mic' | 'stream'
+type Status = 'idle' | 'analysing' | 'result' | 'error'
+
+// Magic numbers — named for grep-ability.
+const STREAM_STABILIZATION_MS = 20_000
+const GAIN_UNMUTED = 1
+const GAIN_MUTED = 0
+
+const { track } = useAnalytics()
+
+const mode = ref<Mode>('file')
+
+// ─── Generation token ────────────────────────────────────────────────────
+// Every time an in-flight audio setup could be invalidated (mode switch, stop,
+// unmount), `invalidate()` increments the counter. Async setups capture their
+// generation at start; after each `await` they bail if the counter has moved.
+// Prevents orphaned AudioContext / BpmAnalyzer after a fast user swap.
+let generation = 0
+const invalidate = () => ++generation
+
+// ─── File ────────────────────────────────────────────────────────────────
+const fileInput = ref<HTMLInputElement | null>(null)
+const isDragOver = ref(false)
+const fileStatus = ref<Status>('idle')
+const fileName = ref<string | null>(null)
+const fileBpm = ref<number | null>(null)
+const fileDuration = ref<number | null>(null)
+const fileElapsedMs = ref<number | null>(null)
+const fileError = ref<string | null>(null)
+
+// ─── Mic ─────────────────────────────────────────────────────────────────
+const micStatus = ref<Status>('idle')
+const micLiveBpm = ref<number | null>(null)
+const micStableBpm = ref<number | null>(null)
+const micError = ref<string | null>(null)
+// `shallowRef` for audio graph nodes — Vue shouldn't deep-track them (they're
+// not reactive targets) and we want consistent `.value = null` semantics.
+const micContext = shallowRef<AudioContext | null>(null)
+const micStream = shallowRef<MediaStream | null>(null)
+const micAnalyzer = shallowRef<BpmAnalyzer | null>(null)
+
+// ─── Stream ──────────────────────────────────────────────────────────────
+const streamUrl = ref('https://ice1.somafm.com/defcon-128-mp3')
+const streamStatus = ref<Status>('idle')
+const streamLiveBpm = ref<number | null>(null)
+const streamStableBpm = ref<number | null>(null)
+const streamError = ref<string | null>(null)
+const streamMuted = ref(false)
+const streamContext = shallowRef<AudioContext | null>(null)
+const streamAudioEl = shallowRef<HTMLAudioElement | null>(null)
+const streamAnalyzer = shallowRef<BpmAnalyzer | null>(null)
+const streamGain = shallowRef<GainNode | null>(null)
+const streamErrorHandler = shallowRef<((event: Event) => void) | null>(null)
+
+const modes: readonly { id: Mode; label: string }[] = [
+  { id: 'file', label: 'File' },
+  { id: 'mic', label: 'Mic' },
+  { id: 'stream', label: 'Stream' },
+] as const
+
+const iconForMode = {
+  file: FileAudio,
+  mic: Mic,
+  stream: Radio,
+} as const
+
+// Strip query + hash from a URL before sending it to analytics — prevents
+// leakage of signed tokens, session IDs, or any other query-encoded secrets.
+function sanitiseUrl(rawUrl: string): string {
+  try {
+    const parsed = new URL(rawUrl)
+    return parsed.origin + parsed.pathname
+  } catch {
+    return ''
+  }
+}
+
+// ─── Mode switching (with teardown) ──────────────────────────────────────
+function setMode(next: Mode) {
+  if (mode.value === next) return
+  invalidate()
+  if (mode.value === 'mic') teardownMic()
+  if (mode.value === 'stream') teardownStream()
+  mode.value = next
+  track('bpm_tab_change', { mode: next })
+}
+
+// ─── File flow ───────────────────────────────────────────────────────────
+function openFilePicker() {
+  fileInput.value?.click()
+}
+
+function onFileChange(event: Event) {
+  const target = event.target as HTMLInputElement
+  const file = target.files?.[0]
+  if (!file) return
+  analyseFile(file, 'browse')
+  target.value = ''
+}
+
+function onDrop(event: DragEvent) {
+  event.preventDefault()
+  isDragOver.value = false
+  const file = event.dataTransfer?.files?.[0]
+  if (!file) return
+  analyseFile(file, 'drop')
+}
+
+function onDragOver(event: DragEvent) {
+  event.preventDefault()
+  isDragOver.value = true
+}
+
+function onDragLeave() {
+  isDragOver.value = false
+}
+
+async function analyseFile(file: File, source: 'drop' | 'browse') {
+  fileName.value = file.name
+  fileStatus.value = 'analysing'
+  fileError.value = null
+  fileBpm.value = null
+  fileDuration.value = null
+  fileElapsedMs.value = null
+
+  track('bpm_file_selected', {
+    source,
+    size_kb: Math.round(file.size / 1024),
+    extension: file.name.split('.').pop()?.toLowerCase() ?? '',
+  })
+
+  const started = performance.now()
+
+  try {
+    const arrayBuffer = await file.arrayBuffer()
+    const audioContext = new AudioContext()
+    const audioBuffer = await audioContext.decodeAudioData(arrayBuffer)
+    const candidates = await analyzeFullBuffer(audioBuffer)
+    audioContext.close().catch((e) => console.debug('[BpmHeroTool] file context close:', e))
+
+    const top = candidates?.[0]?.tempo
+    if (top === undefined) throw new Error('No BPM candidate returned')
+
+    fileBpm.value = Math.round(top)
+    fileDuration.value = audioBuffer.duration
+    fileElapsedMs.value = Math.round(performance.now() - started)
+    fileStatus.value = 'result'
+
+    track('bpm_file_result', {
+      source,
+      bpm: fileBpm.value,
+      duration_s: Math.round(fileDuration.value),
+      elapsed_ms: fileElapsedMs.value,
+    })
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : 'unknown'
+    fileError.value = 'Couldn’t read that file. Try MP3, WAV, or FLAC.'
+    fileStatus.value = 'error'
+    track('bpm_file_error', { source, reason })
+    console.error('[BpmHeroTool] file analysis failed:', error)
+  }
+}
+
+function restartFile() {
+  track('bpm_file_restart')
+  fileStatus.value = 'idle'
+  fileName.value = null
+  fileBpm.value = null
+  fileDuration.value = null
+  fileElapsedMs.value = null
+  fileError.value = null
+}
+
+// ─── Mic flow ────────────────────────────────────────────────────────────
+async function startMic() {
+  if (micStatus.value !== 'idle') return
+
+  track('bpm_mic_clicked')
+
+  micError.value = null
+  micLiveBpm.value = null
+  micStableBpm.value = null
+  micStatus.value = 'analysing'
+
+  // Capture the generation at entry. If anything invalidates it mid-setup
+  // (mode switch, stop, unmount), bail and tear down the locals we've built
+  // so far — they were never committed to component state.
+  const gen = ++generation
+
+  try {
+    const localStream = await navigator.mediaDevices.getUserMedia({ audio: true, video: false })
+    if (gen !== generation) return disposeLocalMic(localStream, null, null)
+
+    const localContext = new AudioContext()
+    await localContext.resume()
+    if (gen !== generation) return disposeLocalMic(localStream, localContext, null)
+
+    const localAnalyzer = await createRealtimeBpmAnalyzer(localContext)
+    if (gen !== generation) return disposeLocalMic(localStream, localContext, localAnalyzer)
+
+    // Commit the locals to component state only after all awaits succeed.
+    micStream.value = localStream
+    micContext.value = localContext
+    micAnalyzer.value = localAnalyzer
+
+    const source = localContext.createMediaStreamSource(localStream)
+    source.connect(localAnalyzer.node)
+    // Intentionally do NOT connect to destination — avoids mic feedback.
+
+    localAnalyzer.on('bpm', (data: BpmCandidates) => {
+      const top = data.bpm?.[0]?.tempo
+      if (top === undefined) return
+      micLiveBpm.value = Math.round(top)
+    })
+
+    localAnalyzer.on('bpmStable', (data: BpmCandidates) => {
+      const top = data.bpm?.[0]?.tempo
+      if (top === undefined) return
+      micStableBpm.value = Math.round(top)
+      track('bpm_mic_stable', { bpm: micStableBpm.value })
+      micStatus.value = 'result'
+    })
+  } catch (error) {
+    if (gen !== generation) return // invalidated during setup — bail quietly
+    const reason = error instanceof Error ? error.message : 'unknown'
+    const denied = error instanceof DOMException && (error.name === 'NotAllowedError' || error.name === 'PermissionDeniedError')
+    micError.value = denied
+      ? 'Microphone access denied. Enable it in your browser settings and try again.'
+      : 'Couldn’t start the microphone. Check your device and try again.'
+    micStatus.value = 'error'
+    track('bpm_mic_error', { reason })
+    console.error('[BpmHeroTool] mic setup failed:', error)
+    // Nothing was committed to component state, and locals are out of scope
+    // here; teardownMic() is a no-op safety net for anything that did land.
+    teardownMic()
+  }
+}
+
+// Dispose locals that were never promoted to component state (race path).
+function disposeLocalMic(
+  stream: MediaStream | null,
+  context: AudioContext | null,
+  analyzer: BpmAnalyzer | null,
+) {
+  try { analyzer?.stop(); analyzer?.disconnect() } catch (e) { console.debug('[BpmHeroTool] mic dispose analyzer:', e) }
+  stream?.getTracks().forEach(t => t.stop())
+  context?.close().catch((e) => console.debug('[BpmHeroTool] mic dispose context:', e))
+}
+
+function teardownMic() {
+  try {
+    micAnalyzer.value?.stop()
+    micAnalyzer.value?.disconnect()
+  } catch (e) {
+    console.debug('[BpmHeroTool] teardownMic analyzer:', e)
+  }
+  micAnalyzer.value = null
+  micStream.value?.getTracks().forEach(t => t.stop())
+  micStream.value = null
+  micContext.value?.close().catch((e) => console.debug('[BpmHeroTool] teardownMic context:', e))
+  micContext.value = null
+}
+
+function stopMic() {
+  track('bpm_mic_stopped')
+  invalidate()
+  teardownMic()
+  micStatus.value = 'idle'
+  micLiveBpm.value = null
+  micStableBpm.value = null
+  micError.value = null
+}
+
+// ─── Stream flow ─────────────────────────────────────────────────────────
+// Note: with `continuousAnalysis: true` the analyzer keeps running after the
+// first stable detection — a live radio stream has no natural "end". We
+// therefore stay in the `'analysing'` status and surface the stable reading
+// as a prominent pill inside the same panel, rather than transitioning to
+// `'result'` (which would imply the session is finished).
+async function startStream() {
+  if (streamStatus.value !== 'idle') return
+  const url = streamUrl.value.trim()
+  if (!url) return
+
+  const sanitised = sanitiseUrl(url)
+  track('bpm_stream_clicked', { url: sanitised })
+
+  streamError.value = null
+  streamLiveBpm.value = null
+  streamStableBpm.value = null
+  streamStatus.value = 'analysing'
+
+  const gen = ++generation
+
+  try {
+    const localAudioEl = new Audio()
+    localAudioEl.crossOrigin = 'anonymous'
+    localAudioEl.src = url
+    localAudioEl.preload = 'auto'
+
+    const localContext = new AudioContext()
+    await localContext.resume()
+    if (gen !== generation) return disposeLocalStream(localAudioEl, localContext, null, null)
+
+    const localAnalyzer = await createRealtimeBpmAnalyzer(localContext, {
+      continuousAnalysis: true,
+      stabilizationTime: STREAM_STABILIZATION_MS,
+    })
+    if (gen !== generation) return disposeLocalStream(localAudioEl, localContext, localAnalyzer, null)
+
+    const source = localContext.createMediaElementSource(localAudioEl)
+    // Analyzer is a sink — it consumes audio for BPM detection and produces no
+    // output. Branch two parallel chains from the source so audio still reaches
+    // the speakers while we analyse:
+    //   source → analyzer.node                    (analysis path)
+    //   source → gainNode → destination           (audio playback, mutable)
+    source.connect(localAnalyzer.node)
+    const localGain = localContext.createGain()
+    localGain.gain.value = streamMuted.value ? GAIN_MUTED : GAIN_UNMUTED
+    source.connect(localGain)
+    localGain.connect(localContext.destination)
+
+    // Commit to component state.
+    streamAudioEl.value = localAudioEl
+    streamContext.value = localContext
+    streamAnalyzer.value = localAnalyzer
+    streamGain.value = localGain
+
+    localAnalyzer.on('bpm', (data: BpmCandidates) => {
+      const top = data.bpm?.[0]?.tempo
+      if (top === undefined) return
+      streamLiveBpm.value = Math.round(top)
+    })
+
+    localAnalyzer.on('bpmStable', (data: BpmCandidates) => {
+      const top = data.bpm?.[0]?.tempo
+      if (top === undefined) return
+      streamStableBpm.value = Math.round(top)
+      track('bpm_stream_stable', { bpm: streamStableBpm.value, url: sanitised })
+    })
+
+    const handler = (): void => {
+      streamError.value = 'Stream failed to load. URL may be unreachable or blocked by CORS.'
+      streamStatus.value = 'error'
+      track('bpm_stream_error', { url: sanitised, reason: 'audio_error' })
+      teardownStream()
+    }
+    streamErrorHandler.value = handler
+    localAudioEl.addEventListener('error', handler)
+
+    await localAudioEl.play()
+  } catch (error) {
+    if (gen !== generation) return // invalidated during setup — bail quietly
+    const reason = error instanceof Error ? error.message : 'unknown'
+    streamError.value = 'Couldn’t play that stream. CORS or network may be blocking it.'
+    streamStatus.value = 'error'
+    track('bpm_stream_error', { url: sanitised, reason })
+    console.error('[BpmHeroTool] stream setup failed:', error)
+    teardownStream()
+  }
+}
+
+function disposeLocalStream(
+  audioEl: HTMLAudioElement | null,
+  context: AudioContext | null,
+  analyzer: BpmAnalyzer | null,
+  gain: GainNode | null,
+) {
+  try { analyzer?.stop(); analyzer?.disconnect() } catch (e) { console.debug('[BpmHeroTool] stream dispose analyzer:', e) }
+  try { gain?.disconnect() } catch (e) { console.debug('[BpmHeroTool] stream dispose gain:', e) }
+  if (audioEl) {
+    audioEl.pause()
+    audioEl.removeAttribute('src')
+    audioEl.load()
+  }
+  context?.close().catch((e) => console.debug('[BpmHeroTool] stream dispose context:', e))
+}
+
+function teardownStream() {
+  try {
+    streamAnalyzer.value?.stop()
+    streamAnalyzer.value?.disconnect()
+  } catch (e) {
+    console.debug('[BpmHeroTool] teardownStream analyzer:', e)
+  }
+  streamAnalyzer.value = null
+  try { streamGain.value?.disconnect() } catch (e) { console.debug('[BpmHeroTool] teardownStream gain:', e) }
+  streamGain.value = null
+  const audioEl = streamAudioEl.value
+  if (audioEl) {
+    // Drop our error listener *before* mutating src — clearing src fires the
+    // audio element's `error` event, which we'd otherwise misread as a real failure.
+    const handler = streamErrorHandler.value
+    if (handler) {
+      audioEl.removeEventListener('error', handler)
+      streamErrorHandler.value = null
+    }
+    audioEl.pause()
+    audioEl.removeAttribute('src')
+    audioEl.load()
+    streamAudioEl.value = null
+  }
+  streamContext.value?.close().catch((e) => console.debug('[BpmHeroTool] teardownStream context:', e))
+  streamContext.value = null
+}
+
+function toggleStreamMute() {
+  streamMuted.value = !streamMuted.value
+  if (streamGain.value) {
+    streamGain.value.gain.value = streamMuted.value ? GAIN_MUTED : GAIN_UNMUTED
+  }
+  track(streamMuted.value ? 'bpm_stream_muted' : 'bpm_stream_unmuted')
+}
+
+function stopStream() {
+  track('bpm_stream_stopped')
+  invalidate()
+  teardownStream()
+  streamStatus.value = 'idle'
+  streamLiveBpm.value = null
+  streamStableBpm.value = null
+  streamError.value = null
+}
+
+// ─── Cleanup on unmount ──────────────────────────────────────────────────
+onBeforeUnmount(() => {
+  invalidate()
+  teardownMic()
+  teardownStream()
+})
+
+// ─── UI helpers ──────────────────────────────────────────────────────────
+const dropZoneClasses = computed(() => ({
+  'bpm-drop-zone-inner': true,
+  'is-drag-over': isDragOver.value,
+}))
+
+function formatDuration(seconds: number): string {
+  const m = Math.floor(seconds / 60)
+  const s = Math.round(seconds % 60)
+  return `${m}:${s.toString().padStart(2, '0')}`
+}
+</script>
+
+<template>
+  <div class="bpm-hero-tool">
+    <div
+      class="bpm-tabs"
+      role="tablist"
+      aria-label="Audio source"
+    >
+      <button
+        v-for="m in modes"
+        :key="m.id"
+        type="button"
+        role="tab"
+        :aria-selected="mode === m.id"
+        :class="['bpm-tab', { 'is-active': mode === m.id }]"
+        @click="setMode(m.id)"
+      >
+        <component
+          :is="iconForMode[m.id]"
+          :size="16"
+          :stroke-width="1.75"
+          aria-hidden="true"
+        />
+        <span>{{ m.label }}</span>
+      </button>
+    </div>
+
+    <div class="bpm-tool-body">
+      <!-- FILE MODE -->
+      <div
+        v-if="mode === 'file'"
+        class="bpm-mode bpm-mode-file"
+      >
+        <template v-if="fileStatus === 'idle'">
+          <div
+            :class="dropZoneClasses"
+            role="button"
+            tabindex="0"
+            aria-label="Drop an audio file or click to browse"
+            @click="openFilePicker"
+            @keydown.enter.prevent="openFilePicker"
+            @keydown.space.prevent="openFilePicker"
+            @dragover="onDragOver"
+            @dragleave="onDragLeave"
+            @drop="onDrop"
+          >
+            <div
+              class="bpm-icon"
+              aria-hidden="true"
+            >
+              <FileAudio
+                :size="52"
+                :stroke-width="1.5"
+              />
+            </div>
+            <div class="bpm-copy">
+              <div class="bpm-headline">
+                Drop audio file
+              </div>
+              <div class="bpm-sub">
+                or click to browse
+              </div>
+            </div>
+          </div>
+          <input
+            ref="fileInput"
+            type="file"
+            accept="audio/*,video/*"
+            class="bpm-file-input"
+            @change="onFileChange"
+          />
+          <div class="bpm-formats">
+            Handles FLAC, WAV &amp; MP3
+          </div>
+        </template>
+
+        <template v-else-if="fileStatus === 'analysing'">
+          <div
+            class="bpm-state bpm-state-analysing"
+            aria-live="polite"
+          >
+            <div
+              class="bpm-spinner"
+              aria-hidden="true"
+            ></div>
+            <div class="bpm-state-name">
+              {{ fileName }}
+            </div>
+            <div class="bpm-state-label">
+              Analysing&hellip;
+            </div>
+          </div>
+        </template>
+
+        <template v-else-if="fileStatus === 'result'">
+          <div
+            class="bpm-state bpm-state-result"
+            aria-live="polite"
+          >
+            <div class="bpm-result-bpm">
+              <span class="bpm-result-number">{{ fileBpm }}</span>
+              <span class="bpm-result-unit">BPM</span>
+            </div>
+            <div class="bpm-state-name">
+              {{ fileName }}
+            </div>
+            <div class="bpm-result-meta">
+              <span v-if="fileDuration !== null">{{ formatDuration(fileDuration) }}</span>
+              <span v-if="fileElapsedMs !== null">· Done in {{ fileElapsedMs }} ms</span>
+            </div>
+            <button
+              type="button"
+              class="bpm-restart-btn"
+              @click="restartFile"
+            >
+              Analyse another
+            </button>
+          </div>
+        </template>
+
+        <template v-else>
+          <div
+            class="bpm-state bpm-state-error"
+            role="alert"
+          >
+            <div class="bpm-state-name">
+              {{ fileName }}
+            </div>
+            <div class="bpm-error-msg">
+              {{ fileError }}
+            </div>
+            <button
+              type="button"
+              class="bpm-restart-btn"
+              @click="restartFile"
+            >
+              Try another
+            </button>
+          </div>
+        </template>
+      </div>
+
+      <!-- MIC MODE -->
+      <div
+        v-else-if="mode === 'mic'"
+        class="bpm-mode bpm-mode-mic"
+      >
+        <template v-if="micStatus === 'idle'">
+          <button
+            type="button"
+            class="bpm-mic-button"
+            aria-label="Detect BPM from microphone"
+            @click="startMic"
+          >
+            <Mic
+              :size="48"
+              :stroke-width="1.5"
+              aria-hidden="true"
+            />
+          </button>
+          <div class="bpm-copy bpm-copy-centered">
+            <div class="bpm-headline">
+              Tap to detect BPM
+            </div>
+            <div class="bpm-sub">
+              From your microphone
+            </div>
+          </div>
+        </template>
+
+        <template v-else-if="micStatus === 'analysing'">
+          <div
+            class="bpm-state bpm-state-analysing bpm-state-live"
+            aria-live="polite"
+          >
+            <div
+              class="bpm-live-indicator"
+              aria-hidden="true"
+            >
+              <span class="bpm-live-dot"></span>
+              Listening
+            </div>
+            <div class="bpm-result-bpm">
+              <span class="bpm-result-number">{{ micLiveBpm ?? '—' }}</span>
+              <span class="bpm-result-unit">BPM</span>
+            </div>
+            <div class="bpm-state-label">
+              Stabilising…
+            </div>
+            <button
+              type="button"
+              class="bpm-restart-btn"
+              @click="stopMic"
+            >
+              Stop
+            </button>
+          </div>
+        </template>
+
+        <template v-else-if="micStatus === 'result'">
+          <div
+            class="bpm-state bpm-state-result"
+            aria-live="polite"
+          >
+            <div class="bpm-result-bpm">
+              <span class="bpm-result-number">{{ micStableBpm }}</span>
+              <span class="bpm-result-unit">BPM</span>
+            </div>
+            <div class="bpm-state-label">
+              Stable from microphone
+            </div>
+            <button
+              type="button"
+              class="bpm-restart-btn"
+              @click="stopMic"
+            >
+              Detect again
+            </button>
+          </div>
+        </template>
+
+        <template v-else>
+          <div
+            class="bpm-state bpm-state-error"
+            role="alert"
+          >
+            <div class="bpm-error-msg">
+              {{ micError }}
+            </div>
+            <button
+              type="button"
+              class="bpm-restart-btn"
+              @click="stopMic"
+            >
+              Try again
+            </button>
+          </div>
+        </template>
+      </div>
+
+      <!-- STREAM MODE -->
+      <div
+        v-else
+        class="bpm-mode bpm-mode-stream"
+      >
+        <template v-if="streamStatus === 'idle'">
+          <label
+            class="bpm-stream-label"
+            for="bpm-stream-url"
+          >Stream URL</label>
+          <input
+            id="bpm-stream-url"
+            v-model="streamUrl"
+            type="url"
+            class="bpm-stream-input"
+            placeholder="https://example.com/stream.mp3"
+            spellcheck="false"
+            autocomplete="off"
+          />
+          <button
+            type="button"
+            class="bpm-stream-btn"
+            @click="startStream"
+          >
+            Analyse stream
+          </button>
+          <div class="bpm-stream-hint">
+            Example from <a
+              href="https://somafm.com/defcon/"
+              target="_blank"
+              rel="noopener"
+            >SomaFM DEF CON Radio</a>
+          </div>
+        </template>
+
+        <template v-else-if="streamStatus === 'analysing'">
+          <div
+            class="bpm-state bpm-state-analysing bpm-state-live"
+            aria-live="polite"
+          >
+            <div
+              class="bpm-live-indicator"
+              aria-hidden="true"
+            >
+              <span class="bpm-live-dot"></span>
+              {{ streamMuted ? 'Analysing (muted)' : 'Playing' }}
+            </div>
+            <div class="bpm-result-bpm">
+              <span class="bpm-result-number">{{ streamLiveBpm ?? '—' }}</span>
+              <span class="bpm-result-unit">BPM</span>
+            </div>
+            <div
+              v-if="streamStableBpm !== null"
+              class="bpm-stable-pill"
+              aria-live="polite"
+            >
+              <span
+                class="bpm-stable-dot"
+                aria-hidden="true"
+              ></span>
+              Stable at {{ streamStableBpm }} BPM
+            </div>
+            <div class="bpm-stream-actions">
+              <button
+                type="button"
+                class="bpm-restart-btn bpm-btn-with-icon"
+                :aria-pressed="streamMuted"
+                @click="toggleStreamMute"
+              >
+                <component
+                  :is="streamMuted ? VolumeX : Volume2"
+                  :size="14"
+                  :stroke-width="1.75"
+                  aria-hidden="true"
+                />
+                <span>{{ streamMuted ? 'Unmute' : 'Mute' }}</span>
+              </button>
+              <button
+                type="button"
+                class="bpm-restart-btn"
+                @click="stopStream"
+              >
+                Stop
+              </button>
+            </div>
+          </div>
+        </template>
+
+        <template v-else>
+          <div
+            class="bpm-state bpm-state-error"
+            role="alert"
+          >
+            <div class="bpm-error-msg">
+              {{ streamError }}
+            </div>
+            <button
+              type="button"
+              class="bpm-restart-btn"
+              @click="stopStream"
+            >
+              Try again
+            </button>
+          </div>
+        </template>
+      </div>
+    </div>
+
+    <div class="bpm-badge">
+      <ShieldCheck
+        :size="12"
+        :stroke-width="2"
+        aria-hidden="true"
+      />
+      Audio stays in your browser
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.bpm-hero-tool {
+  width: 100%;
+  max-width: 440px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 0.75rem;
+  position: relative;
+  z-index: 2;
+}
+
+.bpm-tabs {
+  display: flex;
+  gap: 0.25rem;
+  padding: 0.25rem;
+  background: var(--vp-c-bg-soft);
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 999px;
+  width: 100%;
+}
+
+.bpm-tab {
+  flex: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: var(--vp-c-text-2);
+  background: transparent;
+  border: none;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.bpm-tab:hover:not(.is-active) { color: var(--vp-c-text-1); }
+.bpm-tab.is-active {
+  background: var(--vp-c-bg);
+  color: var(--vp-c-brand-1);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+}
+
+.bpm-tab > :deep(svg) { flex-shrink: 0; }
+
+.bpm-tool-body {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.bpm-mode {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.bpm-mode-file { gap: 0.5rem; }
+
+.bpm-drop-zone-inner {
+  width: 100%;
+  padding: 1.75rem 1.25rem;
+  border: 2px dashed var(--vp-c-divider);
+  border-radius: 16px;
+  background: var(--vp-c-bg-soft);
+  text-align: center;
+  cursor: pointer;
+  transition: border-color 0.2s ease, background 0.2s ease, transform 0.15s ease;
+  outline: none;
+}
+
+.bpm-drop-zone-inner:hover,
+.bpm-drop-zone-inner:focus-visible {
+  border-color: var(--vp-c-brand-1);
+  background: var(--vp-c-bg-alt);
+}
+
+.bpm-drop-zone-inner.is-drag-over {
+  border-color: var(--vp-c-brand-1);
+  background: var(--vp-c-bg-alt);
+  transform: scale(1.01);
+}
+
+.bpm-icon {
+  color: var(--vp-c-brand-1);
+  margin-bottom: 0.5rem;
+  display: flex;
+  justify-content: center;
+  /* Subtle downward float — signals "you can drop something here" without
+     grabbing attention. 3s cycle, 4px travel. Pauses on hover / drag-over. */
+  animation: bpm-icon-float 3s ease-in-out infinite;
+}
+
+.bpm-drop-zone-inner:hover .bpm-icon,
+.bpm-drop-zone-inner:focus-visible .bpm-icon,
+.bpm-drop-zone-inner.is-drag-over .bpm-icon {
+  animation-play-state: paused;
+}
+
+@keyframes bpm-icon-float {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(4px); }
+}
+
+.bpm-headline {
+  font-size: 1.2rem;
+  font-weight: 600;
+  color: var(--vp-c-text-1);
+  letter-spacing: -0.01em;
+}
+
+.bpm-sub {
+  font-size: 0.9rem;
+  color: var(--vp-c-text-2);
+  margin-top: 0.2rem;
+}
+
+.bpm-copy-centered { text-align: center; }
+
+.bpm-file-input { display: none; }
+
+.bpm-formats {
+  font-size: 0.75rem;
+  color: var(--vp-c-text-3);
+  text-align: center;
+}
+
+/* Shared state card */
+.bpm-state {
+  width: 100%;
+  padding: 1.25rem 1rem;
+  background: var(--vp-c-bg-soft);
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 16px;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.bpm-state-name {
+  font-size: 0.85rem;
+  color: var(--vp-c-text-2);
+  word-break: break-all;
+  max-width: 100%;
+}
+
+.bpm-state-label {
+  font-size: 0.9rem;
+  color: var(--vp-c-text-2);
+}
+
+/* Live indicator */
+.bpm-live-indicator {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: var(--vp-c-danger-1, #f43f5e);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.bpm-live-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--vp-c-danger-1, #f43f5e);
+  box-shadow: 0 0 0 0 rgba(244, 63, 94, 0.45);
+  animation: bpm-pulse 1.2s ease-out infinite;
+}
+
+@keyframes bpm-pulse {
+  0% { box-shadow: 0 0 0 0 rgba(244, 63, 94, 0.45); }
+  70% { box-shadow: 0 0 0 8px rgba(244, 63, 94, 0); }
+  100% { box-shadow: 0 0 0 0 rgba(244, 63, 94, 0); }
+}
+
+/* Spinner */
+.bpm-spinner {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  border: 3px solid var(--vp-c-divider);
+  border-top-color: var(--vp-c-brand-1);
+  animation: bpm-spin 0.8s linear infinite;
+}
+
+@keyframes bpm-spin { to { transform: rotate(360deg); } }
+
+/* Result */
+.bpm-result-bpm {
+  display: flex;
+  align-items: baseline;
+  justify-content: center;
+  gap: 0.5rem;
+  line-height: 1;
+}
+
+.bpm-result-number {
+  font-size: 4rem;
+  font-weight: 700;
+  color: var(--vp-c-brand-1);
+  letter-spacing: -0.04em;
+  font-variant-numeric: tabular-nums;
+  min-width: 3.2ch;
+}
+
+.bpm-result-unit {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--vp-c-text-2);
+  letter-spacing: 0.05em;
+}
+
+.bpm-result-meta {
+  font-size: 0.75rem;
+  color: var(--vp-c-text-3);
+  display: flex;
+  gap: 0.4rem;
+  justify-content: center;
+}
+
+.bpm-restart-btn {
+  margin-top: 0.4rem;
+  padding: 0.5rem 1rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--vp-c-text-1);
+  background: var(--vp-c-bg);
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 999px;
+  cursor: pointer;
+  transition: border-color 0.2s ease, color 0.2s ease;
+}
+
+.bpm-restart-btn:hover {
+  border-color: var(--vp-c-brand-1);
+  color: var(--vp-c-brand-1);
+}
+
+.bpm-stream-actions {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+/* Stable pill shown inside stream analysing panel — signals the analyser has
+   stabilised while the stream continues playing (continuousAnalysis=true). */
+.bpm-stable-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.25rem 0.7rem;
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: var(--vp-c-green-1, #10b981);
+  background: color-mix(in srgb, var(--vp-c-green-1, #10b981) 12%, transparent);
+  border-radius: 999px;
+  letter-spacing: 0.02em;
+}
+
+.bpm-stable-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+  flex-shrink: 0;
+}
+
+.bpm-state-error { border-color: var(--vp-c-danger-1, #f43f5e); }
+.bpm-error-msg {
+  font-size: 0.9rem;
+  color: var(--vp-c-danger-1, #f43f5e);
+}
+
+/* Mic */
+.bpm-mic-button {
+  width: 148px;
+  height: 148px;
+  border-radius: 50%;
+  border: none;
+  background: var(--vp-c-bg-soft);
+  color: var(--vp-c-brand-1);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 8px 24px rgba(100, 108, 255, 0.12), inset 0 1px 0 rgba(255, 255, 255, 0.06);
+  transition: transform 0.15s ease, box-shadow 0.2s ease, background 0.2s ease;
+  margin-top: 0.5rem;
+}
+
+.bpm-mic-button:hover {
+  transform: scale(1.03);
+  box-shadow: 0 12px 32px rgba(100, 108, 255, 0.18), inset 0 1px 0 rgba(255, 255, 255, 0.08);
+  background: var(--vp-c-bg-alt);
+}
+
+.bpm-mic-button:active { transform: scale(0.98); }
+
+/* Stream */
+.bpm-mode-stream {
+  gap: 0.6rem;
+  padding: 0.25rem 0.25rem 0;
+  width: 100%;
+}
+
+.bpm-stream-label {
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: var(--vp-c-text-2);
+  align-self: flex-start;
+}
+
+.bpm-stream-input {
+  width: 100%;
+  padding: 0.7rem 0.9rem;
+  font-size: 0.9rem;
+  color: var(--vp-c-text-1);
+  background: var(--vp-c-bg-soft);
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 10px;
+  outline: none;
+  transition: border-color 0.2s ease, background 0.2s ease;
+}
+
+.bpm-stream-input:focus {
+  border-color: var(--vp-c-brand-1);
+  background: var(--vp-c-bg);
+}
+
+.bpm-stream-btn {
+  width: 100%;
+  padding: 0.65rem 1rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--vp-c-bg);
+  background: var(--vp-c-brand-1);
+  border: none;
+  border-radius: 10px;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.1s ease;
+}
+
+.bpm-stream-btn:hover { background: var(--vp-c-brand-2); }
+.bpm-stream-btn:active { transform: translateY(1px); }
+
+.bpm-stream-hint {
+  font-size: 0.75rem;
+  color: var(--vp-c-text-3);
+  text-align: center;
+  width: 100%;
+}
+
+.bpm-stream-hint a {
+  color: var(--vp-c-text-2);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.bpm-badge {
+  font-size: 0.75rem;
+  color: var(--vp-c-text-3);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  align-self: center;
+  margin-top: 0.25rem;
+}
+
+.bpm-badge > :deep(svg) {
+  color: var(--vp-c-green-1, #10b981);
+  flex-shrink: 0;
+}
+
+.bpm-btn-with-icon {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.bpm-btn-with-icon > :deep(svg) { flex-shrink: 0; }
+
+@media (max-width: 640px) {
+  .bpm-drop-zone-inner { padding: 1.25rem 1rem; }
+  .bpm-headline { font-size: 1.05rem; }
+  .bpm-mic-button { width: 128px; height: 128px; }
+  .bpm-result-number { font-size: 3.25rem; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .bpm-spinner { animation: none; }
+  .bpm-live-dot { animation: none; }
+  .bpm-icon { animation: none; }
+  .bpm-drop-zone-inner.is-drag-over { transform: none; }
+  .bpm-mic-button:hover { transform: none; }
+}
+</style>

--- a/docs/.vitepress/components/ExampleEmbed.vue
+++ b/docs/.vitepress/components/ExampleEmbed.vue
@@ -62,18 +62,31 @@ const exampleName = computed(() => {
         sandbox="allow-scripts allow-same-origin allow-forms"
         loading="lazy"
         :title="`${exampleName} Demo`"
-      />
-      <div v-else class="example-error">
+      ></iframe>
+      <div
+        v-else
+        class="example-error"
+      >
         <p>⚠️ Example not available in development mode.</p>
         <p>Run the example locally: <code>cd examples/{{ example }} && npm run dev</code></p>
       </div>
     </div>
     
     <div class="example-links">
-      <a :href="iframeUrl" target="_blank" rel="noopener" class="link-button primary">
+      <a
+        :href="iframeUrl"
+        target="_blank"
+        rel="noopener"
+        class="link-button primary"
+      >
         🚀 Open in new tab
       </a>
-      <a :href="githubUrl" target="_blank" rel="noopener" class="link-button">
+      <a
+        :href="githubUrl"
+        target="_blank"
+        rel="noopener"
+        class="link-button"
+      >
         📖 View source on GitHub
       </a>
     </div>

--- a/docs/.vitepress/composables/useAnalytics.ts
+++ b/docs/.vitepress/composables/useAnalytics.ts
@@ -1,0 +1,43 @@
+// Thin analytics wrapper — pushes events into `window.dataLayer` for GTM to consume.
+// GTM forwards to GA4 (and any other configured tags) via the container dashboard.
+// SSR-safe — no-ops when `window` is undefined.
+
+type EventParams = Record<string, string | number | boolean>
+
+declare global {
+  interface Window {
+    dataLayer?: unknown[]
+  }
+}
+
+export type BpmAnalyticsEvent =
+  | 'bpm_tab_change'
+  | 'bpm_file_selected'
+  | 'bpm_file_result'
+  | 'bpm_file_error'
+  | 'bpm_file_restart'
+  | 'bpm_mic_clicked'
+  | 'bpm_mic_stable'
+  | 'bpm_mic_error'
+  | 'bpm_mic_stopped'
+  | 'bpm_stream_clicked'
+  | 'bpm_stream_stable'
+  | 'bpm_stream_error'
+  | 'bpm_stream_stopped'
+  | 'bpm_stream_muted'
+  | 'bpm_stream_unmuted'
+
+export function useAnalytics() {
+  function track(event: BpmAnalyticsEvent, params: EventParams = {}): void {
+    if (typeof window === 'undefined') return
+
+    window.dataLayer = window.dataLayer || []
+    window.dataLayer.push({ event, ...params })
+
+    if (import.meta.env.DEV) {
+      console.debug('[analytics]', event, params)
+    }
+  }
+
+  return { track }
+}

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -4,10 +4,14 @@ import { createRequire } from 'module'
 const require = createRequire(import.meta.url)
 const pkg = require('../../package.json')
 
+// GTM container for analytics. Change here if the container is ever rotated.
+const GTM_CONTAINER_ID = 'GTM-WF758H3P'
+
 // https://vitepress.dev/reference/site-config
 export default defineConfig({
   title: "Realtime BPM Analyzer",
-  description: "A powerful TypeScript/JavaScript library for detecting the beats-per-minute (BPM) of audio or video sources in real-time",
+  titleTemplate: ":title | Realtime BPM Analyzer",
+  description: "Find the BPM of any song in your browser — free, private, no upload. Detect tempo from files, microphone, or streams in real time.",
 
   // Base URL - using root since deployed to www.realtime-bpm-analyzer.com
   base: '/',
@@ -25,16 +29,25 @@ export default defineConfig({
   
   // Ignore dead links for pages we haven't created yet
   ignoreDeadLinks: [],
+
+  // Inject the GTM noscript fallback right after <body>
+  transformHtml(code) {
+    return code.replace(
+      /<body([^>]*)>/,
+      `<body$1>\n<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=${GTM_CONTAINER_ID}" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>`
+    )
+  },
   
   head: [
-    ['script', { async: '', src: 'https://www.googletagmanager.com/gtag/js?id=G-S911G9WQTM' }],
-    ['script', {}, `window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('config', 'G-S911G9WQTM');`],
+    // Google Tag Manager — container loads GA4 + any future tags from the GTM dashboard.
+    // GA4 measurement ID G-S911G9WQTM must be configured as a tag inside GTM.
+    ['script', {}, `(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','${GTM_CONTAINER_ID}');`],
     ['meta', { name: 'theme-color', content: '#646cff' }],
     ['meta', { property: 'og:type', content: 'website' }],
     ['meta', { property: 'og:locale', content: 'en' }],
     ['meta', { property: 'og:site_name', content: 'Realtime BPM Analyzer' }],
-    ['meta', { property: 'og:title', content: 'Realtime BPM Analyzer' }],
-    ['meta', { property: 'og:description', content: 'A powerful TypeScript/JavaScript library for detecting the beats-per-minute (BPM) of audio or video sources in real-time' }],
+    ['meta', { property: 'og:title', content: 'Realtime BPM Analyzer — Detect BPM Online, Free & Private' }],
+    ['meta', { property: 'og:description', content: 'Find the BPM of any song in your browser — free, private, no upload. Detect tempo from files, microphone, or streams in real time.' }],
     ['meta', { property: 'og:url', content: 'https://www.realtime-bpm-analyzer.com' }],
     ['meta', { property: 'og:image', content: 'https://www.realtime-bpm-analyzer.com/realtime-bpm-analyzer-share.png' }],
     ['meta', { property: 'og:image:width', content: '1280' }],
@@ -51,7 +64,7 @@ export default defineConfig({
       '@context': 'https://schema.org',
       '@type': 'SoftwareSourceCode',
       name: 'Realtime BPM Analyzer',
-      description: 'A powerful TypeScript/JavaScript library for detecting the beats-per-minute (BPM) of audio or video sources in real-time',
+      description: 'Find the BPM of any song in your browser — free, private, no upload. A consumer tool and zero-dependency TypeScript library for detecting tempo in real time.',
       url: 'https://www.realtime-bpm-analyzer.com',
       codeRepository: 'https://github.com/dlepaux/realtime-bpm-analyzer',
       programmingLanguage: ['TypeScript', 'JavaScript'],

--- a/docs/.vitepress/theme/Layout.vue
+++ b/docs/.vitepress/theme/Layout.vue
@@ -1,0 +1,40 @@
+<script setup lang="ts">
+import DefaultTheme from 'vitepress/theme'
+import { defineClientComponent, useData } from 'vitepress'
+
+const { Layout } = DefaultTheme
+const { frontmatter } = useData()
+
+const BpmHeroTool = defineClientComponent(() =>
+  import('../components/BpmHeroTool.vue')
+)
+</script>
+
+<template>
+  <Layout>
+    <template #home-hero-image>
+      <!-- Mobile-only headline block (name + text): appears above the tool so the
+           identity + value prop reads as one unit, then the tool follows as demo.
+           On desktop this block is `display: none` (see custom.css) and the
+           VitePress-rendered `.VPHero .main .name` + `.text` take over.
+           On mobile the VitePress originals are `display: none` — which removes
+           them from the a11y tree — so screen readers see this block as the
+           page's primary heading. No `aria-hidden` here. -->
+      <div class="bpm-mobile-hero-head">
+        <div
+          v-if="frontmatter.hero?.name"
+          class="bpm-mobile-hero-name"
+        >
+          {{ frontmatter.hero.name }}
+        </div>
+        <div
+          v-if="frontmatter.hero?.text"
+          class="bpm-mobile-hero-text"
+        >
+          {{ frontmatter.hero.text }}
+        </div>
+      </div>
+      <BpmHeroTool />
+    </template>
+  </Layout>
+</template>

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -1,5 +1,108 @@
 /* Custom styles for documentation */
 
+/* ── Hero right-column overrides for BpmHeroTool ───────────────────────── */
+
+/* Hide the decorative blurred background circle at all sizes —
+   it's just noise behind an interactive tool. */
+.VPHero .image-bg {
+  display: none !important;
+}
+
+/* Base overrides that apply at every breakpoint:
+   let our tool own the image slot with auto height + full width of the slot,
+   no fixed square, no padding/background/transform tricks. */
+.VPHero .image-container {
+  width: 100% !important;
+  height: auto !important;
+  padding: 0 !important;
+  background: transparent !important;
+  transform: none !important;
+  margin: 0 auto !important;
+  aspect-ratio: auto !important;
+}
+
+.VPHero .image-src {
+  display: none !important;
+}
+
+/* Desktop: the tool sits on the right, vertically centered against the copy. */
+@media (min-width: 960px) {
+  .VPHero .image {
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+  .VPHero .image-container {
+    max-width: 440px;
+  }
+}
+
+/* Mobile-only headline block shown ABOVE the tool (see Layout.vue). Hidden on
+   desktop where the VitePress-rendered .VPHero .main copy is visible on the left. */
+.bpm-mobile-hero-head {
+  display: none;
+}
+
+/* Mobile: VitePress default applies negative margins (-76px top, -24px sides,
+   -48px bottom) on .VPHero .image, which drags the tool under the navbar and
+   into the copy below. Reset those — our tool owns its own spacing. */
+@media (max-width: 959px) {
+  .VPHero .image {
+    margin: 0 !important;
+    padding: 0 !important;
+    width: 100%;
+  }
+  .VPHero .image-container {
+    max-width: 420px;
+    margin: 0 auto 2rem !important;
+  }
+
+  /* Hide the original hero name + text on mobile — we render them above the tool instead. */
+  .VPHero .main .name,
+  .VPHero .main .text {
+    display: none;
+  }
+
+  .bpm-mobile-hero-head {
+    display: block;
+    text-align: center;
+    max-width: 100%;
+    margin: 0 auto 1.75rem;
+  }
+
+  /* Mobile hero name — brand-colored, matches VitePress native .name sizing. */
+  .bpm-mobile-hero-name {
+    font-size: 32px;
+    line-height: 40px;
+    font-weight: 700;
+    letter-spacing: -0.02em;
+    color: var(--vp-home-hero-name-color, var(--vp-c-brand-1));
+    background: var(--vp-home-hero-name-background);
+    -webkit-background-clip: text;
+    background-clip: text;
+    -webkit-text-fill-color: var(--vp-home-hero-name-color, transparent);
+  }
+
+  /* Mobile hero text — the pitch line, paired right under the name. */
+  .bpm-mobile-hero-text {
+    font-size: 32px;
+    line-height: 40px;
+    font-weight: 700;
+    letter-spacing: -0.02em;
+    color: var(--vp-c-text-1);
+    margin-top: 0.25rem;
+  }
+}
+
+@media (min-width: 640px) and (max-width: 959px) {
+  .bpm-mobile-hero-name,
+  .bpm-mobile-hero-text {
+    font-size: 56px;
+    line-height: 64px;
+  }
+}
+
 /* Enhance code blocks */
 .vp-doc div[class*='language-'] {
   margin: 1.5rem 0;

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,12 +1,13 @@
 import DefaultTheme from 'vitepress/theme'
-import type { Theme } from 'vitepress'
+import type { EnhanceAppContext, Theme } from 'vitepress'
 import ExampleEmbed from '../components/ExampleEmbed.vue'
+import Layout from './Layout.vue'
 import './custom.css'
 
 export default {
   extends: DefaultTheme,
-  enhanceApp({ app }: { app: any }) {
-    // Register ExampleEmbed component globally
+  Layout,
+  enhanceApp({ app }: EnhanceAppContext) {
     app.component('ExampleEmbed', ExampleEmbed)
-  }
+  },
 } satisfies Theme

--- a/docs/eslint.config.js
+++ b/docs/eslint.config.js
@@ -1,0 +1,64 @@
+// Flat ESLint config for the VitePress docs site.
+// Covers .ts and .vue files in .vitepress/ with recommended presets.
+
+import js from '@eslint/js';
+import tseslint from 'typescript-eslint';
+import pluginVue from 'eslint-plugin-vue';
+import vueParser from 'vue-eslint-parser';
+import globals from 'globals';
+
+export default [
+  {
+    ignores: [
+      'node_modules/**',
+      '.vitepress/dist/**',
+      '.vitepress/cache/**',
+      'scripts/**',
+      'examples/**',
+      'api/**',
+      'guide/**',
+      '**/*.md',
+    ],
+  },
+
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  ...pluginVue.configs['flat/recommended'],
+
+  {
+    files: ['**/*.ts', '**/*.vue'],
+    languageOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'module',
+      globals: {
+        ...globals.browser,
+        ...globals.es2022,
+      },
+      parser: vueParser,
+      parserOptions: {
+        parser: tseslint.parser,
+        extraFileExtensions: ['.vue'],
+        ecmaFeatures: {jsx: false},
+      },
+    },
+    rules: {
+      // Team conventions — permissive where it counts, strict where it matters.
+      '@typescript-eslint/no-unused-vars': [
+        'warn',
+        {argsIgnorePattern: '^_', varsIgnorePattern: '^_', caughtErrorsIgnorePattern: '^_'},
+      ],
+      '@typescript-eslint/no-explicit-any': 'error',
+      '@typescript-eslint/consistent-type-imports': ['warn', {prefer: 'type-imports'}],
+      'vue/multi-word-component-names': 'off', // VitePress Layout.vue is a valid single-word name
+      'vue/html-self-closing': [
+        'warn',
+        {
+          html: {void: 'always', normal: 'never', component: 'always'},
+          svg: 'always',
+          math: 'always',
+        },
+      ],
+      'no-console': ['warn', {allow: ['debug', 'warn', 'error']}],
+    },
+  },
+];

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,13 +1,17 @@
 ---
 layout: home
+title: Realtime BPM Analyzer — Detect BPM Online, Free & Private
 
 hero:
   name: "Realtime BPM Analyzer"
-  text: "Detect Tempo in Real-Time"
-  tagline: A powerful, dependency-free TypeScript library for analyzing beats-per-minute (BPM) of audio and video sources directly in your browser
+  text: "Find the BPM of Any Song, Instantly"
+  tagline: Free, private BPM detection — right in your browser. Plus a zero-dependency TypeScript library for developers.
+  image:
+    src: /logo.svg
+    alt: Realtime BPM Analyzer
   actions:
     - theme: brand
-      text: Get Started
+      text: Developer Docs
       link: /guide/getting-started
     - theme: alt
       text: View on GitHub
@@ -17,39 +21,39 @@ hero:
       link: /examples/basic-usage
 
 features:
-  - icon: 🎵
+  - icon: '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><path d="M22 12h-2.48a2 2 0 0 0-1.93 1.46l-2.35 8.36a.25.25 0 0 1-.48 0L9.24 2.18a.25.25 0 0 0-.48 0l-2.35 8.36A2 2 0 0 1 4.49 12H2"/></svg>'
     title: Real-Time Analysis
     details: Analyze BPM while audio or video is playing, with instant feedback and continuous monitoring capabilities.
-  
-  - icon: ⚡
+
+  - icon: '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><path d="M12.67 19a2 2 0 0 0 1.416-.588l6.154-6.172a6 6 0 0 0-8.49-8.49L5.586 9.914A2 2 0 0 0 5 11.328V18a1 1 0 0 0 1 1z"/><path d="M16 8 2 22"/><path d="M17.5 15H9"/></svg>'
     title: Zero Dependencies
     details: Built entirely on the Web Audio API with no external dependencies. Lightweight and efficient.
-  
-  - icon: 🎯
+
+  - icon: '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><circle cx="12" cy="12" r="6"/><circle cx="12" cy="12" r="2"/></svg>'
     title: Accurate Detection
     details: Advanced algorithm based on peak detection and interval analysis provides reliable BPM results.
-  
-  - icon: 🎬
+
+  - icon: '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><path d="m18 14 4 4-4 4"/><path d="m18 2 4 4-4 4"/><path d="M2 18h1.973a4 4 0 0 0 3.3-1.7l5.454-8.6a4 4 0 0 1 3.3-1.7H22"/><path d="M2 6h1.972a4 4 0 0 1 3.6 2.2"/><path d="M22 18h-6.041a4 4 0 0 1-3.3-1.8l-.359-.45"/></svg>'
     title: Multiple Sources
     details: Works with audio/video elements, file uploads, microphone input, and streaming sources.
-  
-  - icon: 📦
+
+  - icon: '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><path d="M8 3H7a2 2 0 0 0-2 2v5a2 2 0 0 1-2 2 2 2 0 0 1 2 2v5c0 1.1.9 2 2 2h1"/><path d="M16 21h1a2 2 0 0 0 2-2v-5c0-1.1.9-2 2-2a2 2 0 0 1-2-2V5a2 2 0 0 0-2-2h-1"/></svg>'
     title: TypeScript Support
     details: Written in TypeScript with full type definitions for excellent IDE integration and type safety.
-  
-  - icon: 🎛️
+
+  - icon: '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><path d="M10 5H3"/><path d="M12 19H3"/><path d="M14 3v4"/><path d="M16 17v4"/><path d="M21 12h-9"/><path d="M21 19h-5"/><path d="M21 5h-7"/><path d="M8 10v4"/><path d="M8 12H3"/></svg>'
     title: Flexible Usage
     details: Works with live audio, continuous monitoring, or offline file analysis based on your use case.
-  
-  - icon: 🌐
+
+  - icon: '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M12 2a14.5 14.5 0 0 0 0 20 14.5 14.5 0 0 0 0-20"/><path d="M2 12h20"/></svg>'
     title: Browser Compatible
     details: Supports all modern browsers with Web Audio API. Works with MP3, FLAC, and WAV formats.
-  
-  - icon: 🔧
+
+  - icon: '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22v-5"/><path d="M15 8V2"/><path d="M17 8a1 1 0 0 1 1 1v4a4 4 0 0 1-4 4h-4a4 4 0 0 1-4-4V9a1 1 0 0 1 1-1z"/><path d="M9 8V2"/></svg>'
     title: Easy Integration
     details: Simple API that works with vanilla JS, React, Vue, and any modern framework.
-  
-  - icon: 🎨
+
+  - icon: '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22a1 1 0 0 1 0-20 10 9 0 0 1 10 9 5 5 0 0 1-5 5h-2.25a1.75 1.75 0 0 0-1.4 2.8l.3.4a1.75 1.75 0 0 1-1.4 2.8z"/><circle cx="13.5" cy="6.5" r=".5" fill="currentColor"/><circle cx="17.5" cy="10.5" r=".5" fill="currentColor"/><circle cx="6.5" cy="12.5" r=".5" fill="currentColor"/><circle cx="8.5" cy="7.5" r=".5" fill="currentColor"/></svg>'
     title: Customizable
     details: Configure threshold levels, stabilization time, and analysis parameters to fit your needs.
 ---

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -7,14 +7,59 @@
     "": {
       "name": "realtime-bpm-analyzer-docs",
       "version": "1.0.0",
+      "dependencies": {
+        "lucide-vue-next": "^1.0.0",
+        "realtime-bpm-analyzer": "file:.."
+      },
       "devDependencies": {
+        "@eslint/js": "^10.0.1",
         "@types/node": "^22.10.2",
+        "eslint": "^10.2.1",
+        "eslint-plugin-vue": "^10.8.0",
+        "globals": "^17.5.0",
+        "lucide-static": "^1.8.0",
         "realfavicon": "^0.5.0",
         "tsx": "^4.19.2",
         "typedoc": "^0.28.14",
         "typedoc-plugin-markdown": "^4.9.0",
+        "typescript": "^6.0.3",
+        "typescript-eslint": "^8.59.0",
         "vitepress": "^1.6.4",
-        "vue": "^3.5.13"
+        "vue": "^3.5.13",
+        "vue-eslint-parser": "^10.4.0",
+        "vue-tsc": "^3.2.7"
+      }
+    },
+    "..": {
+      "version": "5.0.6",
+      "license": "Apache-2.0",
+      "workspaces": [
+        "examples/*"
+      ],
+      "devDependencies": {
+        "@commitlint/cli": "^18.5.0",
+        "@commitlint/config-conventional": "^18.5.0",
+        "@semantic-release/changelog": "^6.0.3",
+        "@semantic-release/commit-analyzer": "^13.0.1",
+        "@semantic-release/git": "^10.0.1",
+        "@semantic-release/npm": "^13.1.2",
+        "@semantic-release/release-notes-generator": "^14.1.0",
+        "@types/chai": "^4.3.11",
+        "@types/mocha": "^10.0.6",
+        "@web/dev-server": "^0.4.1",
+        "@web/dev-server-esbuild": "^1.0.1",
+        "@web/test-runner": "^0.18.0",
+        "@web/test-runner-puppeteer": "^0.18.0",
+        "chai": "^5.0.3",
+        "esbuild": "^0.25.0",
+        "eslint": "^8.56.0",
+        "husky": "^8.0.3",
+        "mocha": "^10.2.0",
+        "music-metadata": "^7.14.0",
+        "semantic-release": "^25.0.2",
+        "ts-node": "^10.9.2",
+        "typescript": "^5.3.3",
+        "xo": "^0.56.0"
       }
     },
     "node_modules/@algolia/abtesting": {
@@ -279,7 +324,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
       "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -289,7 +333,6 @@
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -299,7 +342,6 @@
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.5.tgz",
       "integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.28.5"
@@ -315,7 +357,6 @@
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
       "integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
@@ -825,6 +866,173 @@
         "node": ">=18"
       }
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+      "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^3.0.5",
+        "debug": "^4.3.1",
+        "minimatch": "^10.2.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.5.tgz",
+      "integrity": "sha512-eIJYKTCECbP/nsKaaruF6LW967mtbQbsw4JTtSVkUQc9MneSkbrgPJAbKl9nWr0ZeowV8BfsarBmPpBzGelA2w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "eslint": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+      "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.1.tgz",
+      "integrity": "sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
     "node_modules/@gerrit0/mini-shiki": {
       "version": "3.13.1",
       "resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-3.13.1.tgz",
@@ -881,6 +1089,72 @@
         "@types/hast": "^3.0.4"
       }
     },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
     "node_modules/@iconify-json/simple-icons": {
       "version": "1.2.55",
       "resolved": "https://registry.npmjs.org/@iconify-json/simple-icons/-/simple-icons-1.2.55.tgz",
@@ -920,7 +1194,6 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@one-ini/wasm": {
@@ -1490,6 +1763,13 @@
         "tslib": "^2.8.0"
       }
     },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1506,6 +1786,13 @@
       "dependencies": {
         "@types/unist": "*"
       }
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/linkify-it": {
       "version": "5.0.0",
@@ -1566,6 +1853,275 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.0.tgz",
+      "integrity": "sha512-HyAZtpdkgZwpq8Sz3FSUvCR4c+ScbuWa9AksK2Jweub7w4M3yTz4O11AqVJzLYjy/B9ZWPyc81I+mOdJU/bDQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.59.0",
+        "@typescript-eslint/type-utils": "8.59.0",
+        "@typescript-eslint/utils": "8.59.0",
+        "@typescript-eslint/visitor-keys": "8.59.0",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.59.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.0.tgz",
+      "integrity": "sha512-TI1XGwKbDpo9tRW8UDIXCOeLk55qe9ZFGs8MTKU6/M08HWTw52DD/IYhfQtOEhEdPhLMT26Ka/x7p70nd3dzDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.59.0",
+        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/typescript-estree": "8.59.0",
+        "@typescript-eslint/visitor-keys": "8.59.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.0.tgz",
+      "integrity": "sha512-Lw5ITrR5s5TbC19YSvlr63ZfLaJoU6vtKTHyB0GQOpX0W7d5/Ir6vUahWi/8Sps/nOukZQ0IB3SmlxZnjaKVnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.59.0",
+        "@typescript-eslint/types": "^8.59.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.0.tgz",
+      "integrity": "sha512-UzR16Ut8IpA3Mc4DbgAShlPPkVm8xXMWafXxB0BocaVRHs8ZGakAxGRskF7FId3sdk9lgGD73GSFaWmWFDE4dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/visitor-keys": "8.59.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.0.tgz",
+      "integrity": "sha512-91Sbl3s4Kb3SybliIY6muFBmHVv+pYXfybC4Oolp3dvk8BvIE3wOPc+403CWIT7mJNkfQRGtdqghzs2+Z91Tqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.0.tgz",
+      "integrity": "sha512-3TRiZaQSltGqGeNrJzzr1+8YcEobKH9rHnqIp/1psfKFmhRQDNMGP5hBufanYTGznwShzVLs3Mz+gDN7HkWfXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/typescript-estree": "8.59.0",
+        "@typescript-eslint/utils": "8.59.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.0.tgz",
+      "integrity": "sha512-nLzdsT1gdOgFxxxwrlNVUBzSNBEEHJ86bblmk4QAS6stfig7rcJzWKqCyxFy3YRRHXDWEkb2NralA1nOYkkm/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.0.tgz",
+      "integrity": "sha512-O9Re9P1BmBLFJyikRbQpLku/QA3/AueZNO9WePLBwQrvkixTmDe8u76B6CYUAITRl/rHawggEqUGn5QIkVRLMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.59.0",
+        "@typescript-eslint/tsconfig-utils": "8.59.0",
+        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/visitor-keys": "8.59.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.0.tgz",
+      "integrity": "sha512-I1R/K7V07XsMJ12Oaxg/O9GfrysGTmCRhvZJBv0RE0NcULMzjqVpR5kRRQjHsz3J/bElU7HwCO7zkqL+MSUz+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.59.0",
+        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/typescript-estree": "8.59.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.0.tgz",
+      "integrity": "sha512-/uejZt4dSere1bx12WLlPfv8GktzcaDtuJ7s42/HEZ5zGj9oxRaD4bj7qwSunXkf+pbAhFt2zjpHYUiT5lHf0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.59.0",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
@@ -1573,11 +2129,39 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/@volar/language-core": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.28.tgz",
+      "integrity": "sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/source-map": "2.4.28"
+      }
+    },
+    "node_modules/@volar/source-map": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.28.tgz",
+      "integrity": "sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@volar/typescript": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.28.tgz",
+      "integrity": "sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-core": "2.4.28",
+        "path-browserify": "^1.0.1",
+        "vscode-uri": "^3.0.8"
+      }
+    },
     "node_modules/@vue/compiler-core": {
       "version": "3.5.22",
       "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.22.tgz",
       "integrity": "sha512-jQ0pFPmZwTEiRNSb+i9Ow/I/cHv2tXYqsnHKKyCQ08irI2kdF5qmYedmF8si8mA7zepUFmJ2hqzS8CQmNOWOkQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.28.4",
@@ -1591,7 +2175,6 @@
       "version": "3.5.22",
       "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.22.tgz",
       "integrity": "sha512-W8RknzUM1BLkypvdz10OVsGxnMAuSIZs9Wdx1vzA3mL5fNMN15rhrSCLiTm6blWeACwUwizzPVqGJgOGBEN/hA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@vue/compiler-core": "3.5.22",
@@ -1602,7 +2185,6 @@
       "version": "3.5.22",
       "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.22.tgz",
       "integrity": "sha512-tbTR1zKGce4Lj+JLzFXDq36K4vcSZbJ1RBu8FxcDv1IGRz//Dh2EBqksyGVypz3kXpshIfWKGOCcqpSbyGWRJQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.28.4",
@@ -1620,7 +2202,6 @@
       "version": "3.5.22",
       "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.22.tgz",
       "integrity": "sha512-GdgyLvg4R+7T8Nk2Mlighx7XGxq/fJf9jaVofc3IL0EPesTE86cP/8DD1lT3h1JeZr2ySBvyqKQJgbS54IX1Ww==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@vue/compiler-dom": "3.5.22",
@@ -1663,11 +2244,26 @@
         "rfdc": "^1.4.1"
       }
     },
+    "node_modules/@vue/language-core": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.2.7.tgz",
+      "integrity": "sha512-Gn4q/tRxbpVGLEuARQ43p3YELlNAFgRUVCgW9U5Cr+5q4vfD2bWDWpl3ABbJMXUt5xlE1dF8dkigg2aUq7JYYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-core": "2.4.28",
+        "@vue/compiler-dom": "^3.5.0",
+        "@vue/shared": "^3.5.0",
+        "alien-signals": "^3.1.2",
+        "muggle-string": "^0.4.1",
+        "path-browserify": "^1.0.1",
+        "picomatch": "^4.0.4"
+      }
+    },
     "node_modules/@vue/reactivity": {
       "version": "3.5.22",
       "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.22.tgz",
       "integrity": "sha512-f2Wux4v/Z2pqc9+4SmgZC1p73Z53fyD90NFWXiX9AKVnVBEvLFOWCEgJD3GdGnlxPZt01PSlfmLqbLYzY/Fw4A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@vue/shared": "3.5.22"
@@ -1677,7 +2273,6 @@
       "version": "3.5.22",
       "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.22.tgz",
       "integrity": "sha512-EHo4W/eiYeAzRTN5PCextDUZ0dMs9I8mQ2Fy+OkzvRPUYQEyK9yAjbasrMCXbLNhF7P0OUyivLjIy0yc6VrLJQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@vue/reactivity": "3.5.22",
@@ -1688,7 +2283,6 @@
       "version": "3.5.22",
       "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.22.tgz",
       "integrity": "sha512-Av60jsryAkI023PlN7LsqrfPvwfxOd2yAwtReCjeuugTJTkgrksYJJstg1e12qle0NarkfhfFu1ox2D+cQotww==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@vue/reactivity": "3.5.22",
@@ -1701,7 +2295,6 @@
       "version": "3.5.22",
       "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.22.tgz",
       "integrity": "sha512-gXjo+ao0oHYTSswF+a3KRHZ1WszxIqO7u6XwNHqcqb9JfyIL/pbWrrh/xLv7jeDqla9u+LK7yfZKHih1e1RKAQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@vue/compiler-ssr": "3.5.22",
@@ -1715,7 +2308,6 @@
       "version": "3.5.22",
       "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.22.tgz",
       "integrity": "sha512-F4yc6palwq3TT0u+FYf0Ns4Tfl9GRFURDN2gWG7L1ecIaS/4fCIuFOjMTnCyjsu/OK6vaDKLCrGAa+KvvH+h4w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@vueuse/core": {
@@ -1834,6 +2426,46 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/algoliasearch": {
       "version": "5.41.0",
       "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.41.0.tgz",
@@ -1859,6 +2491,13 @@
       "engines": {
         "node": ">= 14.0.0"
       }
+    },
+    "node_modules/alien-signals": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-3.1.2.tgz",
+      "integrity": "sha512-d9dYqZTS90WLiU0I5c6DHj/HcKkF8ZyGN3G5x8wSbslulz70KOxaqCT0hQCo9KOyhVqzqGojvNdJXoTumZOtcw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ansi-regex": {
       "version": "6.2.2",
@@ -2370,12 +3009,42 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
     },
     "node_modules/decode-bmp": {
       "version": "0.2.1",
@@ -2431,6 +3100,13 @@
       "engines": {
         "node": ">=4.0.0"
       }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/default-browser": {
       "version": "5.4.0",
@@ -2653,7 +3329,6 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
       "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -2704,12 +3379,247 @@
         "@esbuild/win32-x64": "0.25.12"
       }
     },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.2.1.tgz",
+      "integrity": "sha512-wiyGaKsDgqXvF40P8mDwiUp/KQjE1FdrIEJsM8PZ3XCiniTMXS3OHWWUe5FI5agoCnr8x4xPrTDZuxsBlNHl+Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.5",
+        "@eslint/config-helpers": "^0.5.5",
+        "@eslint/core": "^1.2.1",
+        "@eslint/plugin-kit": "^0.7.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^9.1.2",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "minimatch": "^10.2.4",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-vue": {
+      "version": "10.8.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-10.8.0.tgz",
+      "integrity": "sha512-f1J/tcbnrpgC8suPN5AtdJ5MQjuXbSU9pGRSSYAuF3SHoiYCOdEX6O22pLaRyLHXvDcOe+O5ENgc1owQ587agA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "natural-compare": "^1.4.0",
+        "nth-check": "^2.1.1",
+        "postcss-selector-parser": "^7.1.0",
+        "semver": "^7.6.3",
+        "xml-name-validator": "^4.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "peerDependencies": {
+        "@stylistic/eslint-plugin": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0",
+        "@typescript-eslint/parser": "^7.0.0 || ^8.0.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "vue-eslint-parser": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@stylistic/eslint-plugin": {
+          "optional": true
+        },
+        "@typescript-eslint/parser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/eslint/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/eslint/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/espree": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^5.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/events-universal": {
       "version": "1.0.1",
@@ -2757,6 +3667,89 @@
       "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/focus-trap": {
       "version": "7.6.5",
@@ -2864,6 +3857,32 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.5.0.tgz",
+      "integrity": "sha512-qoV+HK2yFl/366t2/Cb3+xxPUo5BuMynomoDmiaZBIdbs+0pYbjfZU+twLhGKp4uCZ/+NbtpVepH5bGCxRyy2g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/hast-util-to-html": {
@@ -2999,6 +4018,16 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/image-size": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.2.1.tgz",
@@ -3013,6 +4042,16 @@
       },
       "engines": {
         "node": ">=16.x"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
       }
     },
     "node_modules/inherits": {
@@ -3069,6 +4108,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -3077,6 +4126,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-inside-container": {
@@ -3192,6 +4254,37 @@
         "node": ">=14"
       }
     },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
     "node_modules/kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
@@ -3205,6 +4298,20 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/linkify-it": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
@@ -3215,12 +4322,44 @@
         "uc.micro": "^2.0.0"
       }
     },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/lucide-static": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/lucide-static/-/lucide-static-1.8.0.tgz",
+      "integrity": "sha512-eQJCJuDg3tyQrjP0PwD5eIA4ePd5CMdxkrfyqk3iUQA4VOtsJ0v5T6IBJ5UyR3SYHzUn8HOAEL+I+SLVnOJNIA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/lucide-vue-next": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lucide-vue-next/-/lucide-vue-next-1.0.0.tgz",
+      "integrity": "sha512-V6SPvx1IHTj/UY+FrIYWV5faISsPSb8BnWSFDxAtezWKvWc9ZZ40PDrdu1/Qb5vg4lHWr1hs1BAMGVGm6V1Xdg==",
+      "license": "ISC",
+      "peerDependencies": {
+        "vue": ">=3.0.1"
+      }
     },
     "node_modules/lunr": {
       "version": "2.3.9",
@@ -3233,7 +4372,6 @@
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
       "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
@@ -3457,11 +4595,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/muggle-string": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.4.1.tgz",
+      "integrity": "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3480,6 +4631,13 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
       "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
     },
@@ -3584,6 +4742,56 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
@@ -3651,6 +4859,23 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -3689,7 +4914,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -3709,7 +4933,6 @@
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
       "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -3732,6 +4955,20 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
+      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/preact": {
@@ -3802,6 +5039,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/pretty": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/pretty/-/pretty-2.0.0.tgz",
@@ -3844,6 +5091,16 @@
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/punycode.js": {
@@ -3928,6 +5185,10 @@
       "dependencies": {
         "undici-types": "~6.21.0"
       }
+    },
+    "node_modules/realtime-bpm-analyzer": {
+      "resolved": "..",
+      "link": true
     },
     "node_modules/regex": {
       "version": "6.0.1",
@@ -4242,7 +5503,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -4500,6 +5760,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
     "node_modules/to-data-view": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/to-data-view/-/to-data-view-1.1.0.tgz",
@@ -4516,6 +5793,19 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
       }
     },
     "node_modules/tslib": {
@@ -4558,6 +5848,19 @@
         "node": "*"
       }
     },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/typedoc": {
       "version": "0.28.14",
       "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.14.tgz",
@@ -4596,18 +5899,41 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.0.tgz",
+      "integrity": "sha512-BU3ONW9X+v90EcCH9ZS6LMackcVtxRLlI3XrYyqZIwVSHIk7Qf7bFw1z0M9Q0IUxhTMZCf8piY9hTYaNEIASrw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.59.0",
+        "@typescript-eslint/parser": "8.59.0",
+        "@typescript-eslint/typescript-estree": "8.59.0",
+        "@typescript-eslint/utils": "8.59.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/uc.micro": {
@@ -4727,6 +6053,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/util-deprecate": {
@@ -5312,11 +6648,17 @@
         }
       }
     },
+    "node_modules/vscode-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+      "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/vue": {
       "version": "3.5.22",
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.22.tgz",
       "integrity": "sha512-toaZjQ3a/G/mYaLSbV+QsQhIdMo9x5rrqIpYRObsJ6T/J+RyCSFwN2LHNVH9v8uIcljDNa3QzPVdv3Y6b9hAJQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@vue/compiler-dom": "3.5.22",
@@ -5332,6 +6674,47 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vue-eslint-parser": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-10.4.0.tgz",
+      "integrity": "sha512-Vxi9pJdbN3ZnVGLODVtZ7y4Y2kzAAE2Cm0CZ3ZDRvydVYxZ6VrnBhLikBsRS+dpwj4Jv4UCv21PTEwF5rQ9WXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "eslint-scope": "^8.2.0 || ^9.0.0",
+        "eslint-visitor-keys": "^4.2.0 || ^5.0.0",
+        "espree": "^10.3.0 || ^11.0.0",
+        "esquery": "^1.6.0",
+        "semver": "^7.6.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0"
+      }
+    },
+    "node_modules/vue-tsc": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-3.2.7.tgz",
+      "integrity": "sha512-zc1tL3HoQni1zGTGrwBVRQb7rGP5SWdu/m4rGB6JcnAC5MT5LFZIxF7Y+EJEnt4hGF23d60rXH7gRjHGb5KQQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/typescript": "2.4.28",
+        "@vue/language-core": "3.2.7"
+      },
+      "bin": {
+        "vue-tsc": "bin/vue-tsc.js"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
       }
     },
     "node_modules/whatwg-encoding": {
@@ -5371,6 +6754,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/wrap-ansi": {
@@ -5494,6 +6887,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/xml-name-validator": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
+      "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/yaml": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
@@ -5505,6 +6908,19 @@
       },
       "engines": {
         "node": ">= 14.6"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/zwitch": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -9,18 +9,37 @@
     "docs:generate": "cd .. && typedoc",
     "build:examples": "tsx scripts/build-examples.ts",
     "dev:examples": "tsx scripts/dev-examples.ts",
+    "lib:build": "cd .. && npm run build",
+    "predev": "npm run lib:build",
     "dev": "npm run copy:markdown && npm run docs:generate && vitepress dev",
+    "typecheck": "vue-tsc --noEmit",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "verify": "npm run typecheck && npm run lint",
     "build": "npm run copy:markdown && npm run build:favicon && npm run docs:generate && vitepress build && npm run build:examples",
     "build:favicon": "npx realfavicon generate ../brand/icon.svg favicon-settings.json favicon.json public/favicon",
     "preview": "vitepress preview"
   },
+  "dependencies": {
+    "lucide-vue-next": "^1.0.0",
+    "realtime-bpm-analyzer": "file:.."
+  },
   "devDependencies": {
+    "@eslint/js": "^10.0.1",
     "@types/node": "^22.10.2",
+    "eslint": "^10.2.1",
+    "eslint-plugin-vue": "^10.8.0",
+    "globals": "^17.5.0",
+    "lucide-static": "^1.8.0",
     "realfavicon": "^0.5.0",
     "tsx": "^4.19.2",
     "typedoc": "^0.28.14",
     "typedoc-plugin-markdown": "^4.9.0",
+    "typescript": "^6.0.3",
+    "typescript-eslint": "^8.59.0",
     "vitepress": "^1.6.4",
-    "vue": "^3.5.13"
+    "vue": "^3.5.13",
+    "vue-eslint-parser": "^10.4.0",
+    "vue-tsc": "^3.2.7"
   }
 }

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -1,0 +1,39 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "jsx": "preserve",
+    "strict": true,
+    "noImplicitAny": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "skipLibCheck": true,
+    "allowImportingTsExtensions": false,
+    "allowJs": true,
+    "checkJs": false,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "types": []
+  },
+  "include": [
+    ".vitepress/**/*.ts",
+    ".vitepress/**/*.vue",
+    ".vitepress/**/*.d.ts",
+    "vite-env.d.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    ".vitepress/dist",
+    ".vitepress/cache",
+    "examples",
+    "scripts"
+  ]
+}

--- a/docs/vite-env.d.ts
+++ b/docs/vite-env.d.ts
@@ -1,1 +1,26 @@
-/// <reference types="vite/client" />
+// Local ambient declarations for `import.meta.env`.
+// VitePress bundles Vite internally (nested in node_modules/vitepress/node_modules/vite),
+// so `/// <reference types="vite/client" />` is not resolvable from the docs package
+// root. We declare only the fields our code actually uses.
+//
+// NOTE: `interface` (not `type`) is required — TypeScript only merges ambient
+// declarations for global types like ImportMeta via interface declaration
+// merging. Using `type` would shadow the global instead of augmenting it.
+
+interface ImportMetaEnv {
+  readonly DEV: boolean
+  readonly PROD: boolean
+  readonly SSR: boolean
+  readonly MODE: string
+  readonly BASE_URL: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}
+
+// CSS side-effect imports (e.g. `import './custom.css'`).
+declare module '*.css' {
+  const content: string
+  export default content
+}

--- a/package.json
+++ b/package.json
@@ -51,8 +51,8 @@
   ],
   "scripts": {
     "build": "bash bin/build/library.sh",
-    "docs:dev": "cd docs && npm run dev",
-    "docs:build": "cd docs && npm run build",
+    "docs:dev": "npm run build && cd docs && npm run dev",
+    "docs:build": "npm run build && cd docs && npm run build",
     "docs:preview": "cd docs && npm run preview",
     "examples:install": "npm install --workspaces",
     "examples:build": "npm run build --workspaces --if-present",
@@ -103,7 +103,7 @@
     "semicolon": true,
     "ignores": [
       "examples/**",
-      "docs/scripts/**"
+      "docs/**"
     ],
     "globals": [
       "process",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,15 +1,22 @@
 {
-    "compilerOptions": {
-        "target": "ES2015",
-        "module": "commonjs",
-        "lib": ["dom", "dom.iterable", "es6"],
-        "skipLibCheck": true,
-        "declaration": true,
-        "strict": true,
-        "moduleResolution": "node",
-        "sourceMap": true,
-        "types" : ["mocha"]
-    },
-    "include": ["tests/**/*.ts", "testing/**/*.ts", "github-pages/*.ts", "types/*.ts", "src/*.ts", "processor/*.ts"],
-    "exclude": ["node_modules"]
+  "compilerOptions": {
+    "target": "ES2015",
+    "module": "preserve",
+    "lib": ["dom", "dom.iterable", "es6"],
+    "skipLibCheck": true,
+    "declaration": true,
+    "strict": true,
+    "moduleResolution": "bundler",
+    "sourceMap": true,
+    "types": ["mocha"]
+  },
+  "include": [
+    "tests/**/*.ts",
+    "testing/**/*.ts",
+    "github-pages/*.ts",
+    "types/*.ts",
+    "src/*.ts",
+    "processor/*.ts"
+  ],
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
Pivot the docs site from dev-first to a consumer tool + dev docs hybrid. Adds a three-mode hero analyser (File / Mic / Stream), migrates analytics to GTM, rewrites SEO copy, and introduces TypeScript + ESLint quality gates for the docs workspace.

- Hero tool: race-safe audio graph setup + teardown via generation tokens; File uses analyzeFullBuffer (offline), Mic and Stream use createRealtimeBpmAnalyzer (live). Stream routes a parallel analyser/playback chain with a GainNode mute toggle.
- Lucide icons across tabs, drop zone, mute toggle, privacy badge, and the features grid. Replaces emoji UI chrome.
- Mobile hero: name + pitch above the tool, supporting copy below; VitePress originals hidden at small widths with a11y preserved.
- SEO: consumer-first title + meta description + OG tags + JSON-LD.
- Analytics: migrate raw gtag to GTM (GTM-WF758H3P) with noscript fallback injected via transformHtml. Typed useAnalytics composable pushes all events to window.dataLayer; stream URLs sanitised to origin+pathname before analytics to avoid leaking signed tokens.
- Quality gates: strict docs/tsconfig.json + flat eslint.config.js (Vue + TS recommended presets). CI runs typecheck + lint before building docs.
- Fix CI race where the docs job deployed the pre-release version: now depends on release and checks out ref:main.
- Root tsconfig moved to bundler/preserve (silences the TS 7 node10 deprecation); dist bytes verified identical via npm pack consumer smoke tests (CJS + ESM).
- docs:dev / docs:build at root and docs/predev rebuild the lib first to avoid stale dist during local development.

No library code changed; this is docs-only. Should not trigger a semantic-release version bump.