### PR TITLE
fix(analyzer): scan full chunk when nextIndexPeaks is stale

### DIFF
--- a/src/core/realtime-bpm-analyzer.ts
+++ b/src/core/realtime-bpm-analyzer.ts
@@ -81,7 +81,8 @@ export class RealTimeBpmAnalyzer {
    * Update the computed values
    */
   updateComputedValues() {
-    this.computedStabilizationTimeInSeconds = this.options.stabilizationTime / 1000;
+    this.computedStabilizationTimeInSeconds
+      = this.options.stabilizationTime / 1000;
   }
 
   /**
@@ -103,7 +104,10 @@ export class RealTimeBpmAnalyzer {
     this.minValidThreshold = minThreshold;
 
     await descendingOverThresholds(async threshold => {
-      if (threshold < minThreshold && this.validPeaks[threshold] !== undefined) {
+      if (
+        threshold < minThreshold
+        && this.validPeaks[threshold] !== undefined
+      ) {
         delete this.validPeaks[threshold]; // eslint-disable-line @typescript-eslint/no-dynamic-delete
         delete this.nextIndexPeaks[threshold]; // eslint-disable-line @typescript-eslint/no-dynamic-delete
       }
@@ -120,7 +124,12 @@ export class RealTimeBpmAnalyzer {
    * @param options.bufferSize - Buffer size (4096)
    * @param options.postMessage - Function to post a message to the processor node
    */
-  async analyzeChunk({audioSampleRate, channelData, bufferSize, postMessage}: RealtimeAnalyzeChunkOptions): Promise<void> {
+  async analyzeChunk({
+    audioSampleRate,
+    channelData,
+    bufferSize,
+    postMessage,
+  }: RealtimeAnalyzeChunkOptions): Promise<void> {
     if (this.options.debug) {
       postMessage({type: 'analyzeChunk', data: channelData});
     }
@@ -158,7 +167,10 @@ export class RealTimeBpmAnalyzer {
      */
     this.skipIndexes++;
 
-    const data: BpmCandidates = await computeBpm({audioSampleRate, data: this.validPeaks});
+    const data: BpmCandidates = await computeBpm({
+      audioSampleRate,
+      data: this.validPeaks,
+    });
     const {threshold} = data;
     postMessage({type: 'bpm', data});
 
@@ -173,7 +185,11 @@ export class RealTimeBpmAnalyzer {
     /**
      * After x time, we reinit the analyzer
      */
-    if (this.options.continuousAnalysis && this.effectiveBufferTime / audioSampleRate > this.computedStabilizationTimeInSeconds) {
+    if (
+      this.options.continuousAnalysis
+      && this.effectiveBufferTime / audioSampleRate
+        > this.computedStabilizationTimeInSeconds
+    ) {
       this.reset();
       postMessage({type: 'analyzerReset'});
     }
@@ -202,12 +218,22 @@ export class RealTimeBpmAnalyzer {
         return false;
       }
 
-      /**
-       * Get the next index in the next chunk
-       */
-      const offsetForNextPeak = this.nextIndexPeaks[threshold] % bufferSize; // 0 - 4095
+      // Resume scanning at the offset that corresponds to nextIndexPeaks within
+      // the current chunk. When nextIndexPeaks lies before the chunk (the mute
+      // zone of a prior peak ended in a previous chunk), start from offset 0.
+      // `currentMinIndex` is always a multiple of bufferSize, so for positions
+      // inside the chunk this is equivalent to `nextIndexPeaks % bufferSize`.
+      const offsetForNextPeak = Math.max(
+        0,
+        this.nextIndexPeaks[threshold] - currentMinIndex,
+      );
 
-      const {peaks, threshold: atThreshold} = findPeaksAtThreshold({audioSampleRate, data: channelData, threshold, offset: offsetForNextPeak});
+      const {peaks, threshold: atThreshold} = findPeaksAtThreshold({
+        audioSampleRate,
+        data: channelData,
+        threshold,
+        offset: offsetForNextPeak,
+      });
 
       /**
        * Loop over peaks
@@ -222,7 +248,8 @@ export class RealTimeBpmAnalyzer {
         /**
          * Add current Index + muteTimeInIndexes (10000/44100=0.22s)
          */
-        this.nextIndexPeaks[atThreshold] = index + this.options.muteTimeInIndexes;
+        this.nextIndexPeaks[atThreshold]
+          = index + this.options.muteTimeInIndexes;
 
         /**
          * Store valid relativeChunkPeak Indexes

--- a/tests/unit/realtime-analyzer/find-peaks.test.ts
+++ b/tests/unit/realtime-analyzer/find-peaks.test.ts
@@ -1,0 +1,90 @@
+import {expect} from 'chai';
+import {RealTimeBpmAnalyzer} from '../../../src/core/realtime-bpm-analyzer';
+
+/**
+ * Resolve the exact key string that represents a given threshold
+ * (validPeaks/nextIndexPeaks keys are stringified floats with precision artefacts).
+ */
+function getThresholdKey(
+  analyzer: RealTimeBpmAnalyzer,
+  threshold: number,
+): string {
+  const target = threshold.toFixed(2);
+  const key = Object.keys(analyzer.validPeaks).find(
+    k => Number.parseFloat(k).toFixed(2) === target,
+  );
+  if (!key) {
+    throw new Error(`No threshold key found for ${threshold}`);
+  }
+
+  return key;
+}
+
+/**
+ * Unit tests codifying the resume-offset contract for RealTimeBpmAnalyzer.findPeaks.
+ * See plan/backlog/lib-bug-next-index-peaks-modulo.md
+ */
+describe('RealTimeBpmAnalyzer - findPeaks resume offset', () => {
+  const bufferSize = 4096;
+  const audioSampleRate = 44_100;
+
+  it('should scan from the start of the chunk when nextIndexPeaks lies before currentMinIndex', async () => {
+    // Case C from the ticket: a high-threshold peak fired early, mute-zone ended,
+    // then the signal dropped and several chunks passed. nextIndexPeaks[threshold]
+    // is now an absolute index in the PAST relative to the current chunk window.
+    const analyzer = new RealTimeBpmAnalyzer();
+    const currentMinIndex = bufferSize * 4; // 16384
+    const currentMaxIndex = currentMinIndex + bufferSize; // 20480
+
+    const key090 = getThresholdKey(analyzer, 0.9);
+    analyzer.nextIndexPeaks[key090] = 10_500; // Before currentMinIndex, mute zone long since ended
+
+    const channelData = new Float32Array(bufferSize);
+    const peakChunkOffset = 100;
+    channelData[peakChunkOffset] = 0.95;
+
+    await analyzer.findPeaks({
+      audioSampleRate,
+      channelData,
+      bufferSize,
+      currentMinIndex,
+      currentMaxIndex,
+      postMessage() {
+        // No-op
+      },
+    });
+
+    const expectedAbsoluteIndex = currentMinIndex + peakChunkOffset;
+    expect(analyzer.validPeaks[key090]).to.include(expectedAbsoluteIndex);
+  });
+
+  it('should resume from the correct offset when nextIndexPeaks lies inside the chunk', async () => {
+    // Case B from the ticket: mute-zone of a recent peak extends into the current chunk.
+    // Scan must start at (nextIndex - currentMinIndex) to honour the mute zone.
+    const analyzer = new RealTimeBpmAnalyzer();
+    const currentMinIndex = bufferSize * 4;
+    const currentMaxIndex = currentMinIndex + bufferSize;
+
+    const key090 = getThresholdKey(analyzer, 0.9);
+    // Mute zone ends 500 samples into the current chunk — peaks before 500 must be skipped
+    analyzer.nextIndexPeaks[key090] = currentMinIndex + 500;
+
+    const channelData = new Float32Array(bufferSize);
+    channelData[100] = 0.95; // Inside mute zone — must NOT be detected
+    channelData[1000] = 0.95; // After mute zone — must be detected
+
+    await analyzer.findPeaks({
+      audioSampleRate,
+      channelData,
+      bufferSize,
+      currentMinIndex,
+      currentMaxIndex,
+      postMessage() {
+        // No-op
+      },
+    });
+
+    expect(analyzer.validPeaks[key090]).to.not.include(currentMinIndex + 100);
+    expect(analyzer.validPeaks[key090]).to.include(currentMinIndex + 1000);
+  });
+});


### PR DESCRIPTION
`findPeaks` computed the resume offset as `nextIndexPeaks[threshold] % bufferSize`. That identity holds when `nextIndexPeaks` lies inside the current chunk window (`currentMinIndex` is always a multiple of bufferSize), but fails when it lies BEFORE the chunk — the case where a high-threshold peak fired earlier, its mute zone ended several chunks ago, and the threshold went quiet. The modulo then produced an arbitrary offset mid-chunk, causing peaks in the prefix `[0, offset)` of the current chunk to be missed.

Replace with `Math.max(0, nextIndexPeaks[threshold] - currentMinIndex)`. For positions inside the chunk this is arithmetically identical to the modulo; for positions before the chunk it yields 0, which is the correct behaviour (mute zone has already ended).

The bug manifested on sparse audio (dynamic range, quiet passages) where some thresholds go without fresh peaks for many chunks. Current fixture is dense enough that the bug never triggered.

Refs: plan/backlog/lib-bug-next-index-peaks-modulo.md