### PR TITLE
fix(processor): guard analyzeChunk against re-entrant calls

### DIFF
--- a/src/processor/realtime-bpm-processor.ts
+++ b/src/processor/realtime-bpm-processor.ts
@@ -1,7 +1,12 @@
 import {realtimeBpmProcessorName} from '../core/consts';
 import {chunkAggregator} from '../core/utils';
 import {RealTimeBpmAnalyzer} from '../core/realtime-bpm-analyzer';
-import type {ProcessorInputMessage, AggregateData, RealTimeBpmAnalyzerParameters, ProcessorOutputEvent} from '../core/types';
+import type {
+  ProcessorInputMessage,
+  AggregateData,
+  RealTimeBpmAnalyzerParameters,
+  ProcessorOutputEvent,
+} from '../core/types';
 
 /**
  * Those declaration are from the package @types/audioworklet. But it is not compatible with the lib 'dom'.
@@ -26,49 +31,65 @@ type AudioWorkletProcessorParameters = {
 
 declare var AudioWorkletProcessor: {
   prototype: AudioWorkletProcessor;
-  new(options?: AudioWorkletProcessorParameters): AudioWorkletProcessor;
+  new (options?: AudioWorkletProcessorParameters): AudioWorkletProcessor;
 };
 
 interface AudioWorkletProcessorImpl extends AudioWorkletProcessor {
-  process(inputs: Float32Array[][], outputs: Float32Array[][], parameters: Record<string, Float32Array>): boolean;
+  process(
+    inputs: Float32Array[][],
+    outputs: Float32Array[][],
+    parameters: Record<string, Float32Array>,
+  ): boolean;
 }
 
 interface WorkletGlobalScope {}
 
 declare var WorkletGlobalScope: {
   prototype: WorkletGlobalScope;
-  new(): WorkletGlobalScope;
+  new (): WorkletGlobalScope;
 };
 
 interface AudioWorkletGlobalScope extends WorkletGlobalScope {
   readonly currentFrame: number;
   readonly currentTime: number;
   readonly sampleRate: number;
-  registerProcessor(name: string, processorCtor: AudioWorkletProcessorConstructor): void;
+  registerProcessor(
+    name: string,
+    processorCtor: AudioWorkletProcessorConstructor,
+  ): void;
 }
 
 declare var AudioWorkletGlobalScope: {
   prototype: AudioWorkletGlobalScope;
-  new(): AudioWorkletGlobalScope;
+  new (): AudioWorkletGlobalScope;
 };
 
 interface AudioWorkletProcessorConstructor {
   new (options: any): AudioWorkletProcessorImpl;
 }
 
-declare function registerProcessor(name: string, processorCtor: AudioWorkletProcessorConstructor): void;
+declare function registerProcessor(
+  name: string,
+  processorCtor: AudioWorkletProcessorConstructor,
+): void;
 /* eslint-enable no-var, @typescript-eslint/prefer-function-type, @typescript-eslint/no-empty-interface, @typescript-eslint/consistent-type-definitions, @typescript-eslint/no-redeclare, @typescript-eslint/naming-convention */
 
 export class RealTimeBpmProcessor extends AudioWorkletProcessor {
   aggregate: (pcmData: Float32Array) => AggregateData;
   realTimeBpmAnalyzer: RealTimeBpmAnalyzer;
   stopped = false;
+  // Guards against re-entrant analyzeChunk calls. process() is invoked every
+  // render quantum; without this flag, a slow analysis could have multiple
+  // concurrent invocations mutating the analyzer's shared state.
+  analysisInProgress = false;
 
   constructor(options: AudioWorkletProcessorParameters) {
     super(options);
 
     this.aggregate = chunkAggregator();
-    this.realTimeBpmAnalyzer = new RealTimeBpmAnalyzer(options.processorOptions);
+    this.realTimeBpmAnalyzer = new RealTimeBpmAnalyzer(
+      options.processorOptions,
+    );
 
     this.port.addEventListener('message', this.onMessage.bind(this));
     this.port.start();
@@ -89,7 +110,11 @@ export class RealTimeBpmProcessor extends AudioWorkletProcessor {
    * @param _parameters Parameters
    * @returns Process ended successfully
    */
-  process(inputs: Float32Array[][], _outputs: Float32Array[][], _parameters: Record<string, Float32Array>): boolean {
+  process(
+    inputs: Float32Array[][],
+    _outputs: Float32Array[][],
+    _parameters: Record<string, Float32Array>,
+  ): boolean {
     const currentChunk = inputs[0][0];
 
     if (this.stopped) {
@@ -102,20 +127,35 @@ export class RealTimeBpmProcessor extends AudioWorkletProcessor {
 
     const {isBufferFull, buffer, bufferSize} = this.aggregate(currentChunk);
 
-    if (isBufferFull) {
+    if (isBufferFull && !this.analysisInProgress) {
+      this.analysisInProgress = true;
       // The variable sampleRate is global ! thanks to the AudioWorkletProcessor
-      this.realTimeBpmAnalyzer.analyzeChunk({audioSampleRate: sampleRate, channelData: buffer, bufferSize, postMessage: event => {
-        this.port.postMessage(event);
-      }}).catch((error: unknown) => {
-        // Emit error event to allow user-level error handling
-        this.port.postMessage({
-          type: 'error',
-          data: {
-            message: error instanceof Error ? error.message : 'Unknown error during BPM analysis',
-            error: error instanceof Error ? error : new Error(String(error)),
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+      this.realTimeBpmAnalyzer
+        .analyzeChunk({
+          audioSampleRate: sampleRate,
+          channelData: buffer,
+          bufferSize,
+          postMessage: event => {
+            this.port.postMessage(event);
           },
+        })
+        .catch((error: unknown) => {
+          // Emit error event to allow user-level error handling
+          this.port.postMessage({
+            type: 'error',
+            data: {
+              message:
+                error instanceof Error
+                  ? error.message
+                  : 'Unknown error during BPM analysis',
+              error: error instanceof Error ? error : new Error(String(error)),
+            },
+          });
+        })
+        .finally(() => {
+          this.analysisInProgress = false;
         });
-      });
     }
 
     return true;

--- a/tests/unit/processor/concurrency-guard.test.ts
+++ b/tests/unit/processor/concurrency-guard.test.ts
@@ -1,0 +1,104 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/naming-convention */
+import {expect} from 'chai';
+
+/**
+ * The RealTimeBpmProcessor class extends the AudioWorklet-only `AudioWorkletProcessor`
+ * base class and calls the global `registerProcessor` on module load. Neither exists
+ * on the main thread where tests run. Stub the worklet runtime BEFORE the processor
+ * module is imported so the class can be instantiated and exercised directly.
+ */
+async function loadProcessorModule(): Promise<any> {
+  (globalThis as any).sampleRate = 44_100;
+  (globalThis as any).AudioWorkletProcessor = class {
+    port = {
+      postMessage() {
+        // No-op stub
+      },
+      addEventListener() {
+        // No-op stub
+      },
+      start() {
+        // No-op stub
+      },
+    };
+  };
+
+  (globalThis as any).registerProcessor = () => {
+    // No-op stub
+  };
+
+  return import('../../../src/processor/realtime-bpm-processor');
+}
+
+/**
+ * Concurrency guard contract for RealTimeBpmProcessor.process().
+ * See plan/backlog/lib-bug-analyze-chunk-concurrency.md
+ */
+describe('RealTimeBpmProcessor - analyzeChunk concurrency guard', () => {
+  let RealTimeBpmProcessor: any;
+
+  before(async () => {
+    const mod = await loadProcessorModule();
+    RealTimeBpmProcessor = mod.RealTimeBpmProcessor;
+  });
+
+  it('should not start a second analyzeChunk while the first is still pending', async () => {
+    const processor = new RealTimeBpmProcessor({
+      numberOfInputs: 1,
+      numberOfOutputs: 1,
+      processorOptions: {},
+    });
+
+    let analyzeCount = 0;
+    let resolveAnalyze: () => void = () => {
+      /* Set below */
+    };
+
+    const analyzePromise = new Promise<void>(resolve => {
+      resolveAnalyze = resolve;
+    });
+
+    processor.realTimeBpmAnalyzer.analyzeChunk = async () => {
+      analyzeCount++;
+      await analyzePromise;
+    };
+
+    // Make the aggregator always report "buffer full" so process() always attempts analyzeChunk
+    processor.aggregate = (pcmData: Float32Array) => ({
+      isBufferFull: true,
+      buffer: pcmData,
+      bufferSize: 4096,
+    });
+
+    const chunk: Float32Array[][] = [[new Float32Array(128)]];
+
+    processor.process(chunk, [], {});
+    await Promise.resolve();
+    await Promise.resolve();
+
+    processor.process(chunk, [], {});
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Guard must have blocked the second call
+    expect(
+      analyzeCount,
+      'analyzeChunk must only run once while one is in flight',
+    ).to.equal(1);
+
+    // Allow the first to complete, then verify a subsequent process() CAN fire a new analysis
+    resolveAnalyze();
+    // Drain the .finally() handler (multiple microtask hops because of the chain)
+    for (let i = 0; i < 5; i++) {
+      await Promise.resolve();
+    }
+
+    processor.process(chunk, [], {});
+    await Promise.resolve();
+
+    expect(
+      analyzeCount,
+      'a new analyzeChunk must be able to start after the prior one settles',
+    ).to.equal(2);
+  });
+});


### PR DESCRIPTION
process() fires analyzeChunk as an unawaited async call every time the aggregator buffer fills. Under CPU pressure (slow device, large peak density), analyzeChunk can take longer than the fill interval — a second call then starts while the first is still running. The two interleaved invocations mutate shared analyzer state (skipIndexes, validPeaks, nextIndexPeaks, effectiveBufferTime) across await boundaries, producing unstable BPM readings and out-of-order postMessage events.

Add an `analysisInProgress` boolean toggled with `.finally()`. When set, subsequent buffer-full signals drop their chunk rather than start a concurrent analysis. Dropped chunks under sustained load is strictly better than corrupt interleaved results.

Also adds a unit-level test harness for the processor class: stubs AudioWorkletProcessor + registerProcessor globals, dynamic-imports the module, and exercises the guard with a controllable slow-analyze mock.

Refs: plan/backlog/lib-bug-analyze-chunk-concurrency.md