### PR TITLE
fix(utils): eliminate per-frame allocation and overshoot in chunkAggregator

### DIFF
--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -1,5 +1,11 @@
 import * as consts from './consts';
-import type {Peaks, ValidPeaks, NextIndexPeaks, OnThresholdFunction, AggregateData} from './types';
+import type {
+  Peaks,
+  ValidPeaks,
+  NextIndexPeaks,
+  OnThresholdFunction,
+  AggregateData,
+} from './types';
 
 /**
  * Loop between .9 and minValidThreshold at .2 by default, passing the threshold to the function
@@ -9,7 +15,12 @@ import type {Peaks, ValidPeaks, NextIndexPeaks, OnThresholdFunction, AggregateDa
  * @param thresholdStep thresholdStep usuably 0.05
  * @returns A promise that resolves nothing
  */
-export async function descendingOverThresholds(onThreshold: OnThresholdFunction, minValidThreshold = consts.minValidThreshold, startThreshold = consts.startThreshold, thresholdStep = consts.thresholdStep): Promise<void> {
+export async function descendingOverThresholds(
+  onThreshold: OnThresholdFunction,
+  minValidThreshold = consts.minValidThreshold,
+  startThreshold = consts.startThreshold,
+  thresholdStep = consts.thresholdStep,
+): Promise<void> {
   let threshold = startThreshold;
 
   do {
@@ -29,7 +40,12 @@ export async function descendingOverThresholds(onThreshold: OnThresholdFunction,
  * @param thresholdStep Step size between thresholds (default: 0.05)
  * @returns Object with threshold strings as keys and initialValue as values
  */
-function generateThresholdMap<T>(initialValueFactory: () => T, minValidThreshold = consts.minValidThreshold, startThreshold = consts.startThreshold, thresholdStep = consts.thresholdStep): Record<string, T> {
+function generateThresholdMap<T>(
+  initialValueFactory: () => T,
+  minValidThreshold = consts.minValidThreshold,
+  startThreshold = consts.startThreshold,
+  thresholdStep = consts.thresholdStep,
+): Record<string, T> {
   const object: Record<string, T> = {};
   let threshold = startThreshold;
 
@@ -49,8 +65,17 @@ function generateThresholdMap<T>(initialValueFactory: () => T, minValidThreshold
  * @param thresholdStep thresholdStep usuably 0.05
  * @returns Collection of validPeaks by thresholds
  */
-export function generateValidPeaksModel(minValidThreshold = consts.minValidThreshold, startThreshold = consts.startThreshold, thresholdStep = consts.thresholdStep): ValidPeaks {
-  return generateThresholdMap<Peaks>(() => [], minValidThreshold, startThreshold, thresholdStep);
+export function generateValidPeaksModel(
+  minValidThreshold = consts.minValidThreshold,
+  startThreshold = consts.startThreshold,
+  thresholdStep = consts.thresholdStep,
+): ValidPeaks {
+  return generateThresholdMap<Peaks>(
+    () => [],
+    minValidThreshold,
+    startThreshold,
+    thresholdStep,
+  );
 }
 
 /**
@@ -60,8 +85,17 @@ export function generateValidPeaksModel(minValidThreshold = consts.minValidThres
  * @param thresholdStep Usually 0.05
  * @returns Collection of NextIndexPeaks by thresholds
  */
-export function generateNextIndexPeaksModel(minValidThreshold = consts.minValidThreshold, startThreshold = consts.startThreshold, thresholdStep = consts.thresholdStep): NextIndexPeaks {
-  return generateThresholdMap<number>(() => 0, minValidThreshold, startThreshold, thresholdStep);
+export function generateNextIndexPeaksModel(
+  minValidThreshold = consts.minValidThreshold,
+  startThreshold = consts.startThreshold,
+  thresholdStep = consts.thresholdStep,
+): NextIndexPeaks {
+  return generateThresholdMap<number>(
+    () => 0,
+    minValidThreshold,
+    startThreshold,
+    thresholdStep,
+  );
 }
 
 /**
@@ -69,39 +103,14 @@ export function generateNextIndexPeaksModel(minValidThreshold = consts.minValidT
  * @param bufferSize - Size of the buffer to aggregate (default: 4096)
  * @returns A function that accepts PCM data and aggregates it into chunks.
  */
-export function chunkAggregator(bufferSize = consts.defaultBufferSize): (pcmData: Float32Array) => AggregateData {
-  /**
-   * Track the current buffer fill level.
-   */
-  let _bytesWritten = 0;
-
-  /**
-   * Create a buffer of fixed size.
-   */
-  let buffer: Float32Array = new Float32Array(0);
-
-  /**
-   * Initialize the buffer.
-   */
-  function initBuffer(): void {
-    _bytesWritten = 0;
-    buffer = new Float32Array(0);
-  }
-
-  /**
-   * Checks if the buffer is full.
-   * @returns True if the buffer is full, otherwise false.
-   */
-  function isBufferFull(): boolean {
-    return _bytesWritten === bufferSize;
-  }
-
-  /**
-   * Flushes the buffer.
-   */
-  function flush(): void {
-    initBuffer();
-  }
+export function chunkAggregator(
+  bufferSize = consts.defaultBufferSize,
+): (pcmData: Float32Array) => AggregateData {
+  // One allocation for the lifetime of the aggregator. Previous implementation
+  // allocated a fresh Float32Array on every call (375+ times/second inside the
+  // AudioWorklet callback), producing enough GC pressure to cause audible glitches.
+  const buffer = new Float32Array(bufferSize);
+  let bytesWritten = 0;
 
   /**
    * Aggregates incoming PCM data into chunks.
@@ -109,19 +118,25 @@ export function chunkAggregator(bufferSize = consts.defaultBufferSize): (pcmData
    * @returns Object containing aggregated data and buffer information.
    */
   return function (pcmData: Float32Array): AggregateData {
-    if (isBufferFull()) {
-      flush();
+    if (bytesWritten >= bufferSize) {
+      bytesWritten = 0;
     }
 
-    const newBuffer = new Float32Array(buffer.length + pcmData.length);
-    newBuffer.set(buffer, 0);
-    newBuffer.set(pcmData, buffer.length);
-    buffer = newBuffer;
-    _bytesWritten += pcmData.length;
+    // Clamp to available space. Oversized chunks would otherwise overshoot the
+    // buffer and leave isBufferFull stuck at false (prior bug: `=== bufferSize` check).
+    const writable = Math.min(pcmData.length, bufferSize - bytesWritten);
+    buffer.set(pcmData.subarray(0, writable), bytesWritten);
+    bytesWritten += writable;
+
+    const full = bytesWritten >= bufferSize;
 
     return {
-      isBufferFull: isBufferFull(),
-      buffer,
+      isBufferFull: full,
+      // Full case: return the shared buffer (safe because RealTimeBpmProcessor's
+      // analysisInProgress guard prevents a second analyzeChunk from reading
+      // the buffer while a new chunk is being written).
+      // Partial case: zero-copy view matching the written length.
+      buffer: full ? buffer : buffer.subarray(0, bytesWritten),
       bufferSize,
     };
   };
@@ -133,6 +148,9 @@ export function chunkAggregator(bufferSize = consts.defaultBufferSize): (pcmData
  * @param sampleRate Sample rate, typically 48000, 441000, etc
  * @returns The number of indexes we need to skip
  */
-export function computeIndexesToSkip(durationSeconds: number, sampleRate: number): number {
+export function computeIndexesToSkip(
+  durationSeconds: number,
+  sampleRate: number,
+): number {
   return Math.round(durationSeconds * sampleRate);
 }

--- a/tests/unit/utils/utils.test.ts
+++ b/tests/unit/utils/utils.test.ts
@@ -48,10 +48,15 @@ describe('utils - comprehensive tests', () => {
     it('should iterate from startThreshold down to minThreshold', async () => {
       const thresholds: number[] = [];
 
-      await utils.descendingOverThresholds(async threshold => {
-        thresholds.push(threshold);
-        return false; // Continue iteration
-      }, 0.2, 0.5, 0.1);
+      await utils.descendingOverThresholds(
+        async threshold => {
+          thresholds.push(threshold);
+          return false; // Continue iteration
+        },
+        0.2,
+        0.5,
+        0.1,
+      );
 
       // Algorithm decrements first: 0.5 -> 0.4, 0.3, 0.2, 0.1 (stops when <= 0.2 after iteration)
       expect(thresholds.length).to.equal(4);
@@ -307,10 +312,10 @@ describe('utils - comprehensive tests', () => {
       const largeChunk = new Float32Array(2048);
       const result = aggregate(largeChunk);
 
-      expect(result.buffer.length).to.equal(2048);
-      // Buffer is not "full" because _bytesWritten (2048) !== bufferSize (1024)
-      // It's actually overfull
-      expect(result.isBufferFull).to.be.false;
+      // Oversized chunks are clamped to bufferSize: the first bufferSize
+      // samples are written and isBufferFull reports true. Excess is dropped.
+      expect(result.buffer.length).to.equal(1024);
+      expect(result.isBufferFull).to.be.true;
       expect(result.bufferSize).to.equal(1024);
     });
 
@@ -415,12 +420,56 @@ describe('utils - comprehensive tests', () => {
     });
   });
 
+  // Tests codifying the correctness contract.
+  // See plan/backlog/lib-bug-chunk-aggregator-allocation.md
+  describe('chunkAggregator - correctness contract', () => {
+    it('should report isBufferFull: true when an oversized chunk fills the buffer', () => {
+      const bufferSize = 1024;
+      const aggregate = utils.chunkAggregator(bufferSize);
+
+      const oversized = new Float32Array(2048).fill(0.7);
+      const result = aggregate(oversized);
+
+      expect(
+        result.isBufferFull,
+        'a chunk at least as large as bufferSize must fill the buffer',
+      ).to.be.true;
+    });
+
+    it('should not overshoot the buffer when chunk is larger than bufferSize', () => {
+      const bufferSize = 1024;
+      const aggregate = utils.chunkAggregator(bufferSize);
+
+      const oversized = new Float32Array(5000).fill(0.5);
+      const result = aggregate(oversized);
+
+      expect(
+        result.buffer.length,
+        'returned buffer must be bufferSize-bounded, not overflow',
+      ).to.equal(bufferSize);
+    });
+
+    it('should reuse the same underlying ArrayBuffer across successive chunks (no per-frame allocation)', () => {
+      const aggregate = utils.chunkAggregator(1024);
+
+      const first = aggregate(new Float32Array(256).fill(1));
+      const second = aggregate(new Float32Array(256).fill(2));
+
+      expect(
+        second.buffer.buffer === first.buffer.buffer,
+        'chunkAggregator must not allocate a new ArrayBuffer per call',
+      ).to.be.true;
+    });
+  });
+
   describe('model consistency', () => {
     it('should generate models with consistent threshold ranges', () => {
       const validPeaks = utils.generateValidPeaksModel();
       const nextIndex = utils.generateNextIndexPeaksModel();
 
-      expect(Object.keys(validPeaks).length).to.equal(Object.keys(nextIndex).length);
+      expect(Object.keys(validPeaks).length).to.equal(
+        Object.keys(nextIndex).length,
+      );
     });
 
     it('should allow threshold iteration over generated models', async () => {


### PR DESCRIPTION
The aggregator allocated a fresh `Float32Array` on every invocation and copied the entire accumulated buffer. Inside the AudioWorklet callback (375+ calls/second at 48kHz × 128-sample render quanta) this is steady GC pressure in the audio hot path, enough to cause buffer underruns and audible clicks on low-end hardware.

The fullness check used strict equality (`_bytesWritten === bufferSize`), which silently fails when a chunk ever overshoots the remaining space — the aggregator then accumulates past bufferSize indefinitely while `isBufferFull` stays `false` forever. Low probability at current 128-sample render quanta but a latent correctness bug on platforms with non-standard quantum sizes.

Rewrite the aggregator:
- Pre-allocate one Float32Array for the lifetime of the instance
- Use `buffer.set(pcmData.subarray(0, writable), bytesWritten)` to copy only what fits; clamps oversized chunks via `Math.min` instead of overflowing.
- Change the fullness predicate to `>= bufferSize`
- Return the shared buffer on the full path (safe because ticket 2's `analysisInProgress` guard prevents re-entrant reads). Return a zero-copy `subarray` view on the partial path.

Also rewrites one test that explicitly codified the overshoot bug (oversized chunk previously asserted `isBufferFull: false` with buffer length 2048 — now asserts `isBufferFull: true` with buffer length 1024).

Refs: plan/backlog/lib-bug-chunk-aggregator-allocation.md