### PR TITLE
fix(processor): handle reset and stop messages in onMessage

### DIFF
--- a/src/processor/realtime-bpm-processor.ts
+++ b/src/processor/realtime-bpm-processor.ts
@@ -97,10 +97,28 @@ export class RealTimeBpmProcessor extends AudioWorkletProcessor {
 
   /**
    * Handle message event
-   * @param _event Contain event data from main process
+   * @param event Contain event data from main process
    */
-  onMessage(_event: ProcessorInputMessage): void {
-    // Handle custom message client
+  onMessage(event: ProcessorInputMessage): void {
+    if (!event?.data) {
+      return;
+    }
+
+    switch (event.data.type) {
+      case 'reset': {
+        this.realTimeBpmAnalyzer.reset();
+        break;
+      }
+
+      case 'stop': {
+        this.stopped = true;
+        break;
+      }
+
+      default:
+      // Silently ignore unknown message types so newer main-thread code
+      // sending future message shapes does not crash older workers.
+    }
   }
 
   /**

--- a/tests/unit/processor/onmessage-handlers.test.ts
+++ b/tests/unit/processor/onmessage-handlers.test.ts
@@ -1,0 +1,122 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-argument, @typescript-eslint/naming-convention */
+import {expect} from 'chai';
+
+/**
+ * Stub the worklet runtime so RealTimeBpmProcessor can be instantiated on the
+ * main thread. See concurrency-guard.test.ts for rationale.
+ */
+async function loadProcessorModule(): Promise<any> {
+  (globalThis as any).sampleRate = 44_100;
+  (globalThis as any).AudioWorkletProcessor = class {
+    port = {
+      postMessage() {
+        // No-op stub
+      },
+      addEventListener() {
+        // No-op stub
+      },
+      start() {
+        // No-op stub
+      },
+    };
+  };
+
+  (globalThis as any).registerProcessor = () => {
+    // No-op stub
+  };
+
+  return import('../../../src/processor/realtime-bpm-processor');
+}
+
+/**
+ * OnMessage contract for RealTimeBpmProcessor.
+ * See plan/backlog/lib-bug-processor-onmessage-stub.md
+ */
+describe('RealTimeBpmProcessor - onMessage handlers', () => {
+  let RealTimeBpmProcessor: any;
+
+  before(async () => {
+    const mod = await loadProcessorModule();
+    RealTimeBpmProcessor = mod.RealTimeBpmProcessor;
+  });
+
+  function makeProcessor() {
+    return new RealTimeBpmProcessor({
+      numberOfInputs: 1,
+      numberOfOutputs: 1,
+      processorOptions: {},
+    });
+  }
+
+  it('should reset analyzer state on {type: "reset"} message', () => {
+    const processor = makeProcessor();
+
+    // Populate state so we can detect the reset
+    processor.realTimeBpmAnalyzer.skipIndexes = 42;
+    processor.realTimeBpmAnalyzer.effectiveBufferTime = 999_999;
+    const anyKey = Object.keys(processor.realTimeBpmAnalyzer.validPeaks)[0];
+    processor.realTimeBpmAnalyzer.validPeaks[anyKey].push(1234);
+
+    processor.onMessage({data: {type: 'reset'}});
+
+    expect(
+      processor.realTimeBpmAnalyzer.skipIndexes,
+      'skipIndexes should reset to 1',
+    ).to.equal(1);
+    expect(
+      processor.realTimeBpmAnalyzer.effectiveBufferTime,
+      'effectiveBufferTime should reset to 0',
+    ).to.equal(0);
+    expect(
+      processor.realTimeBpmAnalyzer.validPeaks[anyKey],
+      'validPeaks at the key should be empty after reset',
+    ).to.have.lengthOf(0);
+  });
+
+  it('should set stopped flag on {type: "stop"} message and short-circuit process()', () => {
+    const processor = makeProcessor();
+
+    let analyzeCalled = false;
+    processor.realTimeBpmAnalyzer.analyzeChunk = async () => {
+      analyzeCalled = true;
+    };
+
+    processor.aggregate = (_pcmData: Float32Array) => ({
+      isBufferFull: true,
+      buffer: new Float32Array(4096),
+      bufferSize: 4096,
+    });
+
+    processor.onMessage({data: {type: 'stop'}});
+
+    expect(processor.stopped, 'stopped flag should be true after stop message')
+      .to.be.true;
+
+    const chunk: Float32Array[][] = [[new Float32Array(128)]];
+    const result = processor.process(chunk, [], {});
+
+    expect(
+      result,
+      'process() must still return true so the worklet keeps its slot',
+    ).to.be.true;
+    expect(analyzeCalled, 'analyzeChunk must not fire after stop').to.be.false;
+  });
+
+  it('should silently ignore unknown message types (forward compatibility)', () => {
+    const processor = makeProcessor();
+
+    expect(() => {
+      processor.onMessage({data: {type: 'future-message-type'}});
+    }, 'unknown message types must not throw').to.not.throw();
+
+    expect(processor.stopped).to.be.false;
+  });
+
+  it('should tolerate a message with missing data', () => {
+    const processor = makeProcessor();
+
+    expect(() => {
+      processor.onMessage({});
+    }, 'malformed messages must not throw').to.not.throw();
+  });
+});


### PR DESCRIPTION
The `onMessage` handler was an empty stub: BpmAnalyzer's `reset()` and `stop()` methods post `{type: 'reset'}` / `{type: 'stop'}` events to the worklet, and they silently vanished. `reset()` appeared to do nothing; `stop()` failed to halt processing.

Wire a switch on `event.data.type`:
- 'reset' → realTimeBpmAnalyzer.reset() (clears valid peaks, indices)
- 'stop'  → set stopped flag (process() short-circuits thereafter)
- unknown → silently ignored for forward compatibility

Also guards against malformed messages (missing data) to tolerate future main-thread code that sends different message shapes without crashing older workers.

Refs: plan/backlog/lib-bug-processor-onmessage-stub.md