### PR TITLE
fix(examples): release mic tracks on stop in vanilla-microphone

### DIFF
--- a/examples/03-vanilla-microphone/src/main.ts
+++ b/examples/03-vanilla-microphone/src/main.ts
@@ -126,6 +126,14 @@ async function disconnect(): Promise<void> {
   analyser.disconnect();
   bpmAnalyzer.disconnect();
 
+  // Stop microphone tracks so the browser releases the device.
+  // Without this, the mic LED stays on and the track keeps capturing
+  // until the tab is closed.
+  if (mediaStream) {
+    mediaStream.getTracks().forEach(track => track.stop());
+    mediaStream = null;
+  }
+
   // Reset UI
   startBtn.disabled = false;
   stopBtn.disabled = true;


### PR DESCRIPTION
The vanilla microphone example's `disconnect()` (called on Stop click) suspended the AudioContext and disconnected nodes but never stopped the MediaStream tracks. The browser mic LED stayed on after Stop and the track kept capturing until tab close.

`cleanup()` (called on `beforeunload`) did stop tracks, but it was not on the normal stop path — only on tab close or error. React and Vue counterparts already released tracks correctly; only the vanilla example was inconsistent.

Add the same `mediaStream.getTracks().forEach(track => track.stop())` pattern used by the React (bpm-analyzer.tsx L43-46) and Vue (bpm-analyzer.vue L33-36) examples.

Refs: plan/backlog/examples-microphone-shared-helper.md